### PR TITLE
Enable Disk Partition Resize when Size not specified - Fixes #162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - Enabled PSSA rule violations to fail build - Fixes [Issue #149](https://github.com/PowerShell/StorageDsc/issues/149).
 - Fixed markdown rule violations in CHANGELOG.MD.
+- Disk:
+  - Corrected message strings.
+  - Added message when partition resize required but `AllowDestructive`
+    parameter is not enabled.
+  - Fix error when `Size` not specified and `AllowDestructive` is `$True`
+    and partition can be expanded - Fixes [Issue #162](https://github.com/PowerShell/StorageDsc/issues/162).
+  - Fix incorrect error displaying when newly created partition is not
+    made Read/Write.
 
 ## 4.0.0.0
 

--- a/Modules/StorageDsc/DSCResources/MSFT_Disk/MSFT_Disk.psm1
+++ b/Modules/StorageDsc/DSCResources/MSFT_Disk/MSFT_Disk.psm1
@@ -258,7 +258,7 @@ function Set-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.ClearingDisk -f $DiskIdType, $DiskId)
+                $($localizedData.ClearingDiskMessage -f $DiskIdType, $DiskId)
             ) -join '' )
 
         $disk | Clear-Disk -RemoveData -RemoveOEM -Confirm:$true
@@ -447,7 +447,7 @@ function Set-TargetResource
         {
             # The partition is still readonly - throw an exception
             New-InvalidOperationException `
-                -Message ($localizedData.ParitionIsReadOnlyError -f `
+                -Message ($localizedData.NewParitionIsReadOnlyError -f `
                     $DiskIdType, $DiskId, $partition.PartitionNumber)
         } # if
 
@@ -464,15 +464,27 @@ function Set-TargetResource
 
         $assignDriveLetter = $false
 
+        $supportedSize = ($assignedPartition | Get-PartitionSupportedSize)
+
+        <#
+            If the parition size was not specified then try and make the partition
+            use all possible space on the disk.
+        #>
+        if (-not ($PSBoundParameters.ContainsKey('Size')))
+        {
+            $Size = $supportedSize.SizeMax
+        }
+
         if ($assignedPartition.Size -ne $Size)
         {
+            # A patition resize is required
             if ($AllowDestructive)
             {
                 if ($FSFormat -eq 'ReFS')
                 {
                     Write-Verbose -Message ( @(
                             "$($MyInvocation.MyCommand): "
-                            $($localizedData.ResizeRefsNotPossible `
+                            $($localizedData.ResizeRefsNotPossibleMessage `
                                     -f $DriveLetter, $assignedPartition.Size, $Size)
                         ) -join '' )
 
@@ -481,13 +493,11 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message ( @(
                             "$($MyInvocation.MyCommand): "
-                            $($localizedData.SizeMismatchCorrection `
+                            $($localizedData.SizeMismatchCorrectionMessage `
                                     -f $DriveLetter, $assignedPartition.Size, $Size)
                         ) -join '' )
 
-                    $supportedSize = ($assignedPartition | Get-PartitionSupportedSize)
-
-                    if ($size -gt $supportedSize.SizeMax)
+                    if ($Size -gt $supportedSize.SizeMax)
                     {
                         New-InvalidArgumentException -Message ( @(
                                 "$($MyInvocation.MyCommand): "
@@ -498,6 +508,15 @@ function Set-TargetResource
 
                     $assignedPartition | Resize-Partition -Size $Size
                 }
+            }
+            else
+            {
+                # A partition resize was required but is not allowed
+                Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($localizedData.ResizeRefsNotAllowedMessage `
+                            -f $DriveLetter, $assignedPartition.Size, $Size)
+                ) -join '' )
             }
         }
     }
@@ -554,7 +573,7 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message ( @(
                             "$($MyInvocation.MyCommand): "
-                            $($localizedData.VolumeFormatInProgress -f `
+                            $($localizedData.VolumeFormatInProgressMessage -f `
                                     $DriveLetter, $fileSystem, $FSFormat)
                         ) -join '' )
 

--- a/Modules/StorageDsc/DSCResources/MSFT_Disk/MSFT_Disk.psm1
+++ b/Modules/StorageDsc/DSCResources/MSFT_Disk/MSFT_Disk.psm1
@@ -514,7 +514,7 @@ function Set-TargetResource
                 # A partition resize was required but is not allowed
                 Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
-                    $($localizedData.ResizeRefsNotAllowedMessage `
+                    $($localizedData.ResizeNotAllowedMessage `
                             -f $DriveLetter, $assignedPartition.Size, $Size)
                 ) -join '' )
             }

--- a/Modules/StorageDsc/DSCResources/MSFT_Disk/en-us/MSFT_Disk.strings.psd1
+++ b/Modules/StorageDsc/DSCResources/MSFT_Disk/en-us/MSFT_Disk.strings.psd1
@@ -31,11 +31,12 @@
     VolumeFoundMessage = Found {3} volume with no drive letter on partition '{2}' disk with {0} '{1}'.
     MatchingPartitionFoundMessage = Disk with {0} '{1}' already contains partitions, and partition '{2}' matches required size.
     DriveNotFoundOnPartitionMessage = Disk with {0} '{1}' does not contain a partition assigned to drive letter '{2}'.
-    ClearingDisk = Clearing disk with {0} '{1}' of all existing partitions and volumes.
+    ClearingDiskMessage = Clearing disk with {0} '{1}' of all existing partitions and volumes.
     DiskAlreadyInitializedError = Disk with {0} '{1}' is already initialized with {2}.
     NewParitionIsReadOnlyError = New partition '{2}' on disk with {0} '{1}' did not become writable in the expected time.
-    VolumeFormatInProgress = Switch AllowDestructive is specified. Attempting to format volume on {0} with '{2}', was '{1}'
-    SizeMismatchCorrection = Switch AllowDestructive is specified. Attempting to resize partition {0} from {1} to {2}
-    FreeSpaceViolationError = Attempted to resize partition {0} from {1} to {2} while maximum allowed size was {3}
-    ResizeRefsNotPossible = Skipping resize of {0} from {1} to {2}. Resizing ReFS partitions is currently not possible.
+    VolumeFormatInProgressMessage = Switch AllowDestructive is specified. Attempting to format volume on {0} with '{2}', was '{1}'.
+    SizeMismatchCorrectionMessage = Switch AllowDestructive is specified. Attempting to resize partition {0} from {1} to {2}.
+    FreeSpaceViolationError = Attempted to resize partition {0} from {1} to {2} while maximum allowed size was {3}.
+    ResizeRefsNotPossibleMessage = Skipping resize of {0} from {1} to {2}. Resizing ReFS partitions is currently not possible.
+    ResizeRefsNotAllowedMessage = Skipping resize of {0} from {1} to {2}. AllowDestructive flag is not set to 'True'.
 '@

--- a/Modules/StorageDsc/DSCResources/MSFT_Disk/en-us/MSFT_Disk.strings.psd1
+++ b/Modules/StorageDsc/DSCResources/MSFT_Disk/en-us/MSFT_Disk.strings.psd1
@@ -39,5 +39,5 @@
     SizeMismatchCorrectionMessage = Switch AllowDestructive is specified. Attempting to resize partition {0} from {1} to {2}.
     FreeSpaceViolationError = Attempted to resize partition {0} from {1} to {2} while maximum allowed size was {3}.
     ResizeRefsNotPossibleMessage = Skipping resize of {0} from {1} to {2}. Resizing ReFS partitions is currently not possible.
-    ResizeRefsNotAllowedMessage = Skipping resize of {0} from {1} to {2}. AllowDestructive is not set to 'True'.
+    ResizeNotAllowedMessage = Skipping resize of {0} from {1} to {2}. AllowDestructive is not set to 'True'.
 '@

--- a/Modules/StorageDsc/DSCResources/MSFT_Disk/en-us/MSFT_Disk.strings.psd1
+++ b/Modules/StorageDsc/DSCResources/MSFT_Disk/en-us/MSFT_Disk.strings.psd1
@@ -20,7 +20,8 @@
     DiskReadOnlyMessage = Disk with {0} '{1}' is readonly.
     DiskNotGPTMessage = Disk with {0} '{1}' is initialized with '{2}' partition style. GPT required.
     DriveLetterNotFoundMessage = Drive {0} was not found.
-    SizeMismatchMessage = Partition assigned to drive {0} has size {1}, which does not match expected size {2}.
+    SizeMismatchMessage = Partition assigned to drive {0} has size {1}, which does not match expected size {2}. Set AllowDestructive to 'True' to enable resizing of partition.
+    SizeMismatchWithAllowDestructiveMessage = Partition assigned to drive {0} has size {1}, which does not match expected size {2}.
     AllocationUnitSizeMismatchMessage = Volume assigned to drive {0} has allocation unit size {1} KB does not match expected allocation unit size {2} KB.
     FileSystemFormatMismatch = Volume assigned to drive {0} filesystem format '{1}' does not match expected format '{2}'.
     DriveLabelMismatch = Volume assigned to drive {0} label '{1}' does not match expected label '{2}'.
@@ -38,5 +39,5 @@
     SizeMismatchCorrectionMessage = Switch AllowDestructive is specified. Attempting to resize partition {0} from {1} to {2}.
     FreeSpaceViolationError = Attempted to resize partition {0} from {1} to {2} while maximum allowed size was {3}.
     ResizeRefsNotPossibleMessage = Skipping resize of {0} from {1} to {2}. Resizing ReFS partitions is currently not possible.
-    ResizeRefsNotAllowedMessage = Skipping resize of {0} from {1} to {2}. AllowDestructive flag is not set to 'True'.
+    ResizeRefsNotAllowedMessage = Skipping resize of {0} from {1} to {2}. AllowDestructive is not set to 'True'.
 '@

--- a/Tests/Integration/MSFT_Disk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_Disk.Integration.Tests.ps1
@@ -267,7 +267,7 @@ try
                     $current.DriveLetter      | Should -Be $driveLetterA
                     $current.FSLabel          | Should -Be $FSLabelA
                     $current.FSFormat         | Should -Be 'NTFS'
-                    $current.Size             | Should -Be 952041472
+                    $current.Size             | Should -Be 1040104960
                 }
             }
 

--- a/Tests/Integration/MSFT_Disk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_Disk.Integration.Tests.ps1
@@ -219,11 +219,12 @@ try
                     $current.DiskId           | Should -Be $disk.Number
                     $current.DriveLetter      | Should -Be $driveLetterA
                     $current.FSLabel          | Should -Be $FSLabelA
+                    $current.FSFormat         | Should -Be 'NTFS'
                     $current.Size             | Should -Be 50MB
                 }
             }
 
-            Context "Resize partition on Disk Number $($disk.Number)" {
+            Context "Resize partition on Disk Number $($disk.Number) with AllowDestructive" {
                 It 'Should compile and apply the MOF without throwing' {
                     {
                         # This is to pass to the Config
@@ -235,11 +236,12 @@ try
                                     DiskId      = $disk.Number
                                     DiskIdType  = 'Number'
                                     FSLabel     = $FSLabelA
+                                    FSFormat    = 'NTFS'
                                 }
                             )
                         }
 
-                        & "$($script:DSCResourceName)_Config" `
+                        & "$($script:DSCResourceName)_ConfigAllowDestructive" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
 
@@ -259,11 +261,12 @@ try
 
                 It 'Should have set the resource and all the parameters should match' {
                     $current = Get-DscConfiguration | Where-Object {
-                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_ConfigAllowDestructive"
                     }
                     $current.DiskId           | Should -Be $disk.Number
                     $current.DriveLetter      | Should -Be $driveLetterA
                     $current.FSLabel          | Should -Be $FSLabelA
+                    $current.FSFormat         | Should -Be 'NTFS'
                     $current.Size             | Should -Be 952041472
                 }
             }
@@ -373,7 +376,7 @@ try
                             )
                         }
 
-                        & "$($script:DSCResourceName)_ConfigDestructive" `
+                        & "$($script:DSCResourceName)_ConfigClearDisk" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
 
@@ -393,7 +396,7 @@ try
 
                 It 'should have set the resource and all the parameters should match' {
                     $current = Get-DscConfiguration | Where-Object {
-                        $_.ConfigurationName -eq "$($script:DSCResourceName)_ConfigDestructive"
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_ConfigClearDisk"
                     }
                     $current.DiskId           | Should -Be $disk.UniqueId
                     $current.DriveLetter      | Should -Be $driveLetterA

--- a/Tests/Integration/MSFT_Disk.config.ps1
+++ b/Tests/Integration/MSFT_Disk.config.ps1
@@ -27,7 +27,40 @@ configuration MSFT_Disk_Config {
     }
 }
 
-configuration MSFT_Disk_ConfigDestructive {
+configuration MSFT_Disk_ConfigAllowDestructive {
+
+    Import-DscResource -ModuleName StorageDsc
+
+    node localhost {
+        if ($Node.Size)
+        {
+            Disk Integration_Test
+            {
+                DiskId           = $Node.DiskId
+                DiskIdType       = $Node.DiskIdType
+                DriveLetter      = $Node.DriveLetter
+                FSLabel          = $Node.FSLabel
+                Size             = $Node.Size
+                FSFormat         = $Node.FSFormat
+                AllowDestructive = $true
+            }
+        }
+        else
+        {
+            Disk Integration_Test
+            {
+                DiskId           = $Node.DiskId
+                DiskIdType       = $Node.DiskIdType
+                DriveLetter      = $Node.DriveLetter
+                FSLabel          = $Node.FSLabel
+                FSFormat         = $Node.FSFormat
+                AllowDestructive = $true
+            }
+        }
+    }
+}
+
+configuration MSFT_Disk_ConfigClearDisk {
 
     Import-DscResource -ModuleName StorageDsc
 

--- a/Tests/Unit/MSFT_Disk.Tests.ps1
+++ b/Tests/Unit/MSFT_Disk.Tests.ps1
@@ -137,6 +137,10 @@ try
             FileSystem      = 'ReFS'
             DriveLetter     = $script:testDriveLetter
         }
+
+        $script:parameterFilter_MockedDisk0Number = {
+            $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number'
+        }
         #endregion
 
         #region functions for mocking pipeline
@@ -314,7 +318,7 @@ try
 
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -361,7 +365,7 @@ try
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly 1
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Get-Partition -Exactly 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly 1
                 }
@@ -564,7 +568,7 @@ try
 
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -609,7 +613,7 @@ try
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly 1
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Get-Partition -Exactly 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly 1
                 }
@@ -819,7 +823,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0Readonly } `
                     -Verifiable
 
@@ -867,7 +871,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 1
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -885,7 +889,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0OfflineRaw } `
                     -Verifiable
 
@@ -934,7 +938,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 1
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -952,7 +956,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0Raw } `
                     -Verifiable
 
@@ -1003,7 +1007,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -1021,7 +1025,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1066,7 +1070,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -1084,7 +1088,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1111,13 +1115,17 @@ try
 
                 $startTime = Get-Date
 
-                It 'Should throw' {
+                $errorRecord = Get-InvalidOperationRecord `
+                    -Message ($LocalizedData.NewParitionIsReadOnlyError -f `
+                        'Number', $script:mockedDisk0Mbr.Number, $script:mockedPartitionNoDriveLetterReadOnly.PartitionNumber)
+
+                It 'Should throw NewParitionIsReadOnlyError' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -Driveletter $script:testDriveLetter `
                             -Verbose
-                    } | Should -Throw
+                    } | Should -Throw $errorRecord
                 }
 
                 $endTime = Get-Date
@@ -1129,7 +1137,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 31
@@ -1148,7 +1156,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0Mbr } `
                     -Verifiable
 
@@ -1177,7 +1185,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
@@ -1278,7 +1286,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1311,7 +1319,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -1326,7 +1334,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1363,7 +1371,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -1378,7 +1386,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1422,7 +1430,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -1437,7 +1445,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1473,7 +1481,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -1488,7 +1496,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1526,7 +1534,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -1538,11 +1546,11 @@ try
                 }
             }
 
-            Context 'AllowDestructive: Online GPT disk with matching partition/volume without assigned drive letter and wrong size' {
+            Context 'When AllowDestructive enabled with Online GPT disk with matching partition/volume without assigned drive letter and wrong size' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1554,8 +1562,8 @@ try
                 Mock `
                     -CommandName New-Partition `
                     -ParameterFilter {
-                    $DriveLetter -eq $script:testDriveLetter
-                } `
+                        $DriveLetter -eq $script:testDriveLetter
+                    } `
                     -MockWith { $script:mockedPartitionNoDriveLetter } `
                     -Verifiable
 
@@ -1588,7 +1596,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
                     Assert-MockCalled -CommandName New-Partition -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
@@ -1600,11 +1608,11 @@ try
                 }
             }
 
-            Context 'AllowDestructive: Online GPT disk with matching partition/volume but wrong size and remaining size too small' {
+            Context 'When AllowDestructive enabled with Online GPT disk with matching partition/volume but wrong size and remaining size too small' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1616,11 +1624,11 @@ try
                 Mock `
                     -CommandName Get-PartitionSupportedSize `
                     -MockWith {
-                    return @{
-                        SizeMin = 0
-                        SizeMax = 1
-                    }
-                } `
+                        return @{
+                            SizeMin = 0
+                            SizeMax = 1
+                        }
+                    } `
                     -Verifiable
 
                 # mocks that should not be called
@@ -1633,7 +1641,12 @@ try
                 Mock -CommandName Set-Volume
                 Mock -CommandName Resize-Partition
 
-                It 'Should throw' {
+                $errorRecord = Get-InvalidArgumentRecord `
+                    -Message ($LocalizedData.FreeSpaceViolationError -f `
+                        $script:mockedPartition.DriveLetter, $script:mockedPartition.Size, ($script:mockedPartitionSize + 1024), 1) `
+                    -ArgumentName 'Size'
+
+                It 'Should throw FreeSpaceViolationError' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -1642,13 +1655,13 @@ try
                             -AllowDestructive $true `
                             -FSLabel 'NewLabel' `
                             -Verbose
-                    } | Should -Throw
+                    } | Should -Throw $errorRecord
                 }
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -1657,14 +1670,87 @@ try
                     Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
                     Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
                     Assert-MockCalled -CommandName Set-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-PartitionSupportedSize -Exactly -Times 1
+                    Assert-MockCalled -CommandName Resize-Partition -Exactly -Times 0
                 }
             }
 
-            Context 'AllowDestructive: Online GPT disk with matching partition/volume but wrong size and ReFS' {
+            Context 'When AllowDestructive enabled with Size not specified on Online GPT disk with matching partition/volume but wrong size' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
+                    -MockWith { $script:mockedDisk0 } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Partition `
+                    -MockWith { $script:mockedPartition } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-PartitionSupportedSize `
+                    -MockWith {
+                        return @{
+                            SizeMin = 0
+                            SizeMax = 2GB
+                        }
+                    } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Resize-Partition `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolume } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Volume `
+                    -Verifiable
+
+                # mocks that should not be called
+                Mock -CommandName Set-Disk
+                Mock -CommandName Initialize-Disk
+                Mock -CommandName New-Partition
+                Mock -CommandName Set-Partition
+                Mock -CommandName Format-Volume
+
+                It 'Should not throw' {
+                    {
+                        Set-TargetResource `
+                            -DiskId $script:mockedDisk0.Number `
+                            -Driveletter $script:testDriveLetter `
+                            -AllowDestructive $true `
+                            -FSLabel 'NewLabel' `
+                            -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMock
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-PartitionSupportedSize -Exactly -Times 1
+                    Assert-MockCalled -CommandName Resize-Partition -Exactly -Times 1
+                }
+            }
+
+            Context 'When AllowDestructive enabled with Online GPT disk with matching partition/volume but wrong size and ReFS' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1682,6 +1768,17 @@ try
                     -CommandName Set-Volume `
                     -Verifiable
 
+                Mock `
+                    -CommandName Get-PartitionSupportedSize `
+                    -MockWith {
+                        return @{
+                            SizeMin = 0
+                            SizeMax = 1
+                        }
+                    } `
+                    -Verifiable
+
+
                 # mocks that should not be called
                 Mock -CommandName Set-Disk
                 Mock -CommandName Initialize-Disk
@@ -1689,7 +1786,6 @@ try
                 Mock -CommandName Format-Volume
                 Mock -CommandName Set-Partition
                 Mock -CommandName Resize-Partition
-                Mock  -CommandName Get-PartitionSupportedSize
 
                 It 'Should not throw an exception' {
                     {
@@ -1707,7 +1803,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -1716,16 +1812,16 @@ try
                     Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
                     Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
                     Assert-MockCalled -CommandName Set-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-PartitionSupportedSize -Exactly -Times 1
                     Assert-MockCalled -CommandName Resize-Partition -Exactly -Times 0
-                    Assert-MockCalled -CommandName Get-PartitionSupportedSize -Exactly -Times 0
                 }
             }
 
-            Context 'AllowDestructive: Online GPT disk with matching partition/volume but wrong format' {
+            Context 'When AllowDestructive enabled with Online GPT disk with matching partition/volume but wrong format' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1769,7 +1865,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -1780,11 +1876,11 @@ try
                 }
             }
 
-            Context 'AllowDestructive: Online GPT disk containing arbitrary partitions' {
+            Context 'When AllowDestructive enabled with Online GPT disk containing arbitrary partitions' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1828,7 +1924,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 2 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
@@ -1852,7 +1948,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0Offline } `
                     -Verifiable
 
@@ -1880,7 +1976,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
@@ -2049,7 +2145,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0Raw } `
                     -Verifiable
 
@@ -2077,7 +2173,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
@@ -2088,7 +2184,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -2127,7 +2223,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
@@ -2184,7 +2280,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -2222,7 +2318,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
@@ -2233,7 +2329,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -2272,7 +2368,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
@@ -2283,7 +2379,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -2321,7 +2417,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
@@ -2332,7 +2428,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -2367,7 +2463,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
@@ -2378,7 +2474,7 @@ try
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
-                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -2419,7 +2515,7 @@ try
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMock
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
-                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1

--- a/Tests/Unit/MSFT_Disk.Tests.ps1
+++ b/Tests/Unit/MSFT_Disk.Tests.ps1
@@ -1944,7 +1944,7 @@ try
                 -CommandName Get-CimInstance `
                 -MockWith { $script:mockedCim }
 
-            Context 'Test disk does not exist using Disk Number' {
+            Context 'When testing disk does not exist using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -1983,7 +1983,7 @@ try
                 }
             }
 
-            Context 'Test disk offline using Disk Unique Id' {
+            Context 'When testing disk offline using Disk Unique Id' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2022,7 +2022,7 @@ try
                 }
             }
 
-            Context 'Test disk offline using Unique Id' {
+            Context 'When testing disk offline using Unique Id' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2062,7 +2062,7 @@ try
                 }
             }
 
-            Context 'Test disk offline using Disk Guid' {
+            Context 'When testing disk offline using Disk Guid' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2102,7 +2102,7 @@ try
                 }
             }
 
-            Context 'Test disk read only using Disk Number' {
+            Context 'When testing disk read only using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2141,7 +2141,7 @@ try
                 }
             }
 
-            Context 'Test online unformatted disk using Disk Number' {
+            Context 'When testing online unformatted disk using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2180,7 +2180,7 @@ try
                 }
             }
 
-            Context 'Test mismatching partition size using Disk Number' {
+            Context 'When testing mismatching partition size using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2230,7 +2230,169 @@ try
                 }
             }
 
-            Context 'Test mismatched AllocationUnitSize using Disk Number' {
+            Context 'When testing mismatching partition size with AllowDestructive using Disk Number' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
+                    -MockWith { $script:mockedDisk0 } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Partition `
+                    -MockWith { $script:mockedPartition } `
+                    -Verifiable
+
+                # mocks that should not be called
+                Mock -CommandName Get-PartitionSupportedSize
+                Mock -CommandName Get-Volume
+                Mock -CommandName Get-CimInstance
+
+                $script:result = $null
+
+                It 'Should not throw an exception' {
+                    {
+                        $script:result = Test-TargetResource `
+                            -DiskId $script:mockedDisk0.Number `
+                            -DriveLetter $script:testDriveLetter `
+                            -AllocationUnitSize 4096 `
+                            -Size ($script:mockedPartitionSize + 1MB) `
+                            -AllowDestructive $true `
+                            -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be false' {
+                    $script:result | Should -Be $false
+                }
+
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMock
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-PartitionSupportedSize -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
+                }
+            }
+
+            Context 'When testing mismatching partition size without Size specified using Disk Number' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
+                    -MockWith { $script:mockedDisk0 } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Partition `
+                    -MockWith { $script:mockedPartition } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-PartitionSupportedSize `
+                    -MockWith {
+                        return @{
+                            SizeMin = 0
+                            SizeMax = $script:mockedPartition.Size + 1024
+                        }
+                    } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolume } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -MockWith { $script:mockedCim } `
+                    -Verifiable
+
+                $script:result = $null
+
+                It 'Should not throw an exception' {
+                    {
+                        $script:result = Test-TargetResource `
+                            -DiskId $script:mockedDisk0.Number `
+                            -DriveLetter $script:testDriveLetter `
+                            -AllocationUnitSize 4096 `
+                            -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be true' {
+                    $script:result | Should -Be $true
+                }
+
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMock
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-PartitionSupportedSize -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
+                }
+            }
+
+            Context 'When testing mismatching partition size with AllowDestructive and without Size specified using Disk Number' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
+                    -MockWith { $script:mockedDisk0 } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Partition `
+                    -MockWith { $script:mockedPartition } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-PartitionSupportedSize `
+                    -MockWith {
+                        return @{
+                            SizeMin = 0
+                            SizeMax = $script:mockedPartition.Size + 1024
+                        }
+                    } `
+                    -Verifiable
+
+                # mocks that should not be called
+                Mock -CommandName Get-Volume
+                Mock -CommandName Get-CimInstance
+
+                $script:result = $null
+
+                It 'Should not throw an exception' {
+                    {
+                        $script:result = Test-TargetResource `
+                            -DiskId $script:mockedDisk0.Number `
+                            -DriveLetter $script:testDriveLetter `
+                            -AllocationUnitSize 4096 `
+                            -AllowDestructive $true `
+                            -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be false' {
+                    $script:result | Should -Be $false
+                }
+
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMock
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-PartitionSupportedSize -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
+                }
+            }
+
+            Context 'When testing mismatched AllocationUnitSize using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2276,7 +2438,7 @@ try
                 }
             }
 
-            Context 'Test mismatching FSFormat using Disk Number' {
+            Context 'When testing mismatching FSFormat using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2325,7 +2487,7 @@ try
                 }
             }
 
-            Context 'Test mismatching FSFormat using Disk Number and AllowDestructive' {
+            Context 'When testing mismatching FSFormat using Disk Number and AllowDestructive' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2375,7 +2537,7 @@ try
                 }
             }
 
-            Context 'Test mismatching FSLabel using Disk Number' {
+            Context 'When testing mismatching FSLabel using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2424,7 +2586,7 @@ try
                 }
             }
 
-            Context 'Test mismatching DriveLetter using Disk Number' {
+            Context 'When testing mismatching DriveLetter using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2470,7 +2632,7 @@ try
                 }
             }
 
-            Context 'Test all disk properties matching using Disk Number' {
+            Context 'When testing all disk properties matching using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `


### PR DESCRIPTION
#### Pull Request (PR) description
- Disk:
  - Corrected message strings.
  - Added message when partition resize required but `AllowDestructive`
    parameter is not enabled.
  - Fix error when `Size` not specified and `AllowDestructive` is `$True`
    and partition can be expanded - Fixes [Issue #162](https://github.com/PowerShell/StorageDsc/issues/162).
  - Fix incorrect error displaying when newly created partition is not
    made Read/Write.

#### This Pull Request (PR) fixes the following issues
- Fixes #162 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing when you have a moment?
