### PR TITLE
diskaccesspath: fixes issue 145 drive letter assignment to mountpoint volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@
 
 - DiskAccessPath
   Update the resource to not assign a drive letter by default when adding
-  a disk access path. Adding a Set-Partition -NoDefaultDriveLetter $NoDefaultDriveLetter block
-  defaulting to true. When adding access paths the disks will no longer have
+  a disk access path. Adding a Set-Partition -NoDefaultDriveLetter
+  $NoDefaultDriveLetter block defaulting to true.
+  When adding access paths the disks will no longer have
   drive letters automatically assigned on next reboot which is the desired
   behavior.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   When adding access paths the disks will no longer have
   drive letters automatically assigned on next reboot which is the desired
   behavior.
+  -whitespace deploy 1
 
   Fixes [Issue #145](https://github.com/PowerShell/StorageDsc/issues/145).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## Unreleased
 
 - Opt-in to Example publishing to PowerShell Gallery - fixes [Issue #186](https://github.com/PowerShell/StorageDsc/issues/186).
+- DiskAccessPath
+  Updated the resource to not assign a drive letter by default when adding
+  a disk access path. Adding a Set-Partition -NoDefaultDriveLetter
+  $NoDefaultDriveLetter block defaulting to true.
+  When adding access paths the disks will no longer have
+  drive letters automatically assigned on next reboot which is the desired
+  behavior.
+  Fixes [Issue #145](https://github.com/PowerShell/StorageDsc/issues/145).
 
 ## 4.4.0.0
 
@@ -13,15 +21,6 @@
 - Moved the Code of Conduct text out of the README.md and into a
   CODE\_OF\_CONDUCT.md file.
 - Explicitly removed extra hidden files from release package
-
-- DiskAccessPath
-  Updated the resource to not assign a drive letter by default when adding
-  a disk access path. Adding a Set-Partition -NoDefaultDriveLetter
-  $NoDefaultDriveLetter block defaulting to true.
-  When adding access paths the disks will no longer have
-  drive letters automatically assigned on next reboot which is the desired
-  behavior.
-  Fixes [Issue #145](https://github.com/PowerShell/StorageDsc/issues/145).
 
 ## 4.3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Moved the Code of Conduct text out of the README.md and into a
   CODE\_OF\_CONDUCT.md file.
 
+- DiskAccessPath
+  update the resource to not assign a drive letter by default when adding
+  a disk access path. Fixes [Issue #145](https://github.com/PowerShell/StorageDsc/issues/145).
+
 ## 4.3.0.0
 
 - WaitForDisk:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
   When adding access paths the disks will no longer have
   drive letters automatically assigned on next reboot which is the desired
   behavior.
-  -whitespace deploy 1
 
   Fixes [Issue #145](https://github.com/PowerShell/StorageDsc/issues/145).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@
   CODE\_OF\_CONDUCT.md file.
 
 - DiskAccessPath
-  update the resource to not assign a drive letter by default when adding
-  a disk access path. Fixes [Issue #145](https://github.com/PowerShell/StorageDsc/issues/145).
+  Update the resource to not assign a drive letter by default when adding
+  a disk access path. Adding a Set-Partition -NoDefaultDriveLetter $NoDefaultDriveLetter block
+  defaulting to true. When adding access paths the disks will no longer have
+  drive letters automatically assigned on next reboot which is the desired
+  behavior.
+
+  Fixes [Issue #145](https://github.com/PowerShell/StorageDsc/issues/145).
 
 ## 4.3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,12 @@
 - Explicitly removed extra hidden files from release package
 
 - DiskAccessPath
-  Update the resource to not assign a drive letter by default when adding
+  Updated the resource to not assign a drive letter by default when adding
   a disk access path. Adding a Set-Partition -NoDefaultDriveLetter
   $NoDefaultDriveLetter block defaulting to true.
   When adding access paths the disks will no longer have
   drive letters automatically assigned on next reboot which is the desired
   behavior.
-
   Fixes [Issue #145](https://github.com/PowerShell/StorageDsc/issues/145).
 
 ## 4.3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,13 @@
 ## Unreleased
 
 - Opt-in to Example publishing to PowerShell Gallery - fixes [Issue #186](https://github.com/PowerShell/StorageDsc/issues/186).
-- DiskAccessPath
-  Updated the resource to not assign a drive letter by default when adding
-  a disk access path. Adding a Set-Partition -NoDefaultDriveLetter
-  $NoDefaultDriveLetter block defaulting to true.
-  When adding access paths the disks will no longer have
-  drive letters automatically assigned on next reboot which is the desired
-  behavior.
-  Fixes [Issue #145](https://github.com/PowerShell/StorageDsc/issues/145).
+- DiskAccessPath:
+  - Updated the resource to not assign a drive letter by default when adding
+    a disk access path. Adding a Set-Partition -NoDefaultDriveLetter
+    $NoDefaultDriveLetter block defaulting to true.
+    When adding access paths the disks will no longer have
+    drive letters automatically assigned on next reboot which is the desired
+    behavior - Fixes [Issue #145](https://github.com/PowerShell/StorageDsc/issues/145).
 
 ## 4.4.0.0
 

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -522,8 +522,6 @@ function Set-TargetResource
     $assignedPartition = $partition |
         Where-Object -Property AccessPaths -Contains -Value $AccessPath
 
-    if ($assignedPartition.NoDefaultDriveLetter)
-    {
         if ($assignedPartition.NoDefaultDriveLetter -ne $NoDefaultDriveLetter)
         {
             Write-Verbose -Message ( @(
@@ -536,7 +534,6 @@ function Set-TargetResource
                 -DiskNumber $disk.Number `
                 -NoDefaultDriveLetter $NoDefaultDriveLetter
         } # if
-    } # if
 
 } # Set-TargetResource
 

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -501,6 +501,7 @@ function Set-TargetResource
             -DiskNumber $disk.Number `
             -PartitionNumber $partition.PartitionNumber
 
+        # setting the partition property NoDefaultDriveLetter to True to prevent adding drive letter on reboot
         Set-Partition -PartitionNumber $partition.PartitionNumber `
         -DiskNumber $disk.Number `
         -NoDefaultDriveLetter $NoDefaultDriveLetter

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -125,7 +125,7 @@ function Get-TargetResource
         DiskId               = $DiskId
         DiskIdType           = $DiskIdType
         AccessPath           = $AccessPath
-        NoDefaultDriveLetter = $partition.NoDefaultDriveLetter
+        NoDefaultDriveLetter = $assignedPartition.NoDefaultDriveLetter
         Size                 = $assignedPartition.Size
         FSLabel              = $FSLabel
         AllocationUnitSize   = $blockSize

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -55,6 +55,10 @@ function Get-TargetResource
         [System.String]
         $AccessPath,
 
+        [Parameter()]
+        [System.Boolean]
+        $NoDefaultDriveLetter = $true,
+
         [Parameter(Mandatory = $true)]
         [System.String]
         $DiskId,
@@ -115,13 +119,14 @@ function Get-TargetResource
             -ErrorAction SilentlyContinue).BlockSize
 
     $returnValue = @{
-        DiskId             = $DiskId
-        DiskIdType         = $DiskIdType
-        AccessPath         = $AccessPath
-        Size               = $assignedPartition.Size
-        FSLabel            = $FSLabel
-        AllocationUnitSize = $blockSize
-        FSFormat           = $fileSystem
+        DiskId               = $DiskId
+        DiskIdType           = $DiskIdType
+        AccessPath           = $AccessPath
+        NoDefaultDriveLetter = $partition.NoDefaultDriveLetter
+        Size                 = $assignedPartition.Size
+        FSLabel              = $FSLabel
+        AllocationUnitSize   = $blockSize
+        FSFormat             = $fileSystem
     }
     $returnValue
 } # Get-TargetResource

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -512,16 +512,29 @@ function Set-TargetResource
             -DiskNumber $disk.Number `
             -PartitionNumber $partition.PartitionNumber
 
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($localizedData.SuccessfullyInitializedMessage -f $AccessPath)
+            ) -join '' )
+    } # if
+
+    #get the current partition state for NoDefaultDriveLetter
+    $partition = $disk | Get-Partition -ErrorAction SilentlyContinue
+
+    if ($partition.NoDefaultDriveLetter -ne $NoDefaultDriveLetter)
+    {
+
         # setting the partition property NoDefaultDriveLetter to True to prevent adding drive letter on reboot
         Set-Partition -PartitionNumber $partition.PartitionNumber `
-        -DiskNumber $disk.Number `
-        -NoDefaultDriveLetter $NoDefaultDriveLetter
+            -DiskNumber $disk.Number `
+            -NoDefaultDriveLetter $NoDefaultDriveLetter
 
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
                 $($localizedData.SuccessfullyInitializedMessage -f $AccessPath)
             ) -join '' )
     } # if
+
 } # Set-TargetResource
 
 <#

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -671,7 +671,7 @@ function Test-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.NoDefaultDriveLetterMismatchMessage -f $NoDefaultDriveLetter)
+                $($localizedData.NoDefaultDriveLetterMismatchMessage -f $partition.NoDefaultDriveLetter, $NoDefaultDriveLetter)
             ) -join '' )
         return $false
     } # if

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -523,7 +523,6 @@ function Set-TargetResource
 
     if ($partition.NoDefaultDriveLetter -ne $NoDefaultDriveLetter)
     {
-
         # setting the partition property NoDefaultDriveLetter to True to prevent adding drive letter on reboot
         Set-Partition -PartitionNumber $partition.PartitionNumber `
             -DiskNumber $disk.Number `

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -424,7 +424,7 @@ function Set-TargetResource
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
                 $($localizedData.PartitionAlreadyAssignedMessage -f `
-                        $AccessPath, $partition.PartitionNumber)
+                        $AccessPath, $assignedPartition.PartitionNumber)
             ) -join '' )
 
         $assignAccessPath = $false

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -522,9 +522,9 @@ function Set-TargetResource
     $assignedPartition = $partition |
         Where-Object -Property AccessPaths -Contains -Value $AccessPath
 
-    if ($partition.NoDefaultDriveLetter)
+    if ($assignedPartition.NoDefaultDriveLetter)
     {
-        if ($partition.NoDefaultDriveLetter -ne $NoDefaultDriveLetter)
+        if ($assignedPartition.NoDefaultDriveLetter -ne $NoDefaultDriveLetter)
         {
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -162,6 +162,10 @@ function Set-TargetResource
         [System.String]
         $AccessPath,
 
+        [Parameter()]
+        [System.Boolean]
+        $NoDefaultDriveLetter = $true,
+
         [Parameter(Mandatory = $true)]
         [System.String]
         $DiskId,
@@ -496,6 +500,10 @@ function Set-TargetResource
             -AccessPath $AccessPath `
             -DiskNumber $disk.Number `
             -PartitionNumber $partition.PartitionNumber
+
+        Set-Partition -PartitionNumber $partition.PartitionNumber `
+        -DiskNumber $disk.Number `
+        -NoDefaultDriveLetter $NoDefaultDriveLetter
 
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -667,7 +667,6 @@ function Test-TargetResource
     $partition = $disk | Get-Partition -ErrorAction SilentlyContinue
 
     # Check if the partition NoDefaultDriveLetter parameter is correct
-
     if ($partition.NoDefaultDriveLetter -ne $NoDefaultDriveLetter)
     {
         Write-Verbose -Message ( @(

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -522,17 +522,20 @@ function Set-TargetResource
     $partition = $disk | Get-Partition |
         Where-Object -Property AccessPaths -Contains -Value $AccessPath -ErrorAction SilentlyContinue
 
-    if ($partition.NoDefaultDriveLetter -ne $NoDefaultDriveLetter)
+    if ($partition.NoDefaultDriveLetter)
     {
-        Write-Verbose -Message ( @(
-                "$($MyInvocation.MyCommand): "
-                "$($localizedData.NoDefaultDriveLetterMismatchMessage -f $partition.NoDefaultDriveLetter, $NoDefaultDriveLetter)"
-            ) -join '' )
+        if ($partition.NoDefaultDriveLetter -ne $NoDefaultDriveLetter)
+        {
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    "$($localizedData.NoDefaultDriveLetterMismatchMessage -f $partition.NoDefaultDriveLetter, $NoDefaultDriveLetter)"
+                ) -join '' )
 
-        # setting the partition property NoDefaultDriveLetter to True to prevent adding drive letter on reboot
-        Set-Partition -PartitionNumber $partition.PartitionNumber `
-            -DiskNumber $disk.Number `
-            -NoDefaultDriveLetter $NoDefaultDriveLetter
+            # setting the partition property NoDefaultDriveLetter to True to prevent adding drive letter on reboot
+            Set-Partition -PartitionNumber $partition.PartitionNumber `
+                -DiskNumber $disk.Number `
+                -NoDefaultDriveLetter $NoDefaultDriveLetter
+        } # if
     } # if
 
 } # Set-TargetResource

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -526,7 +526,7 @@ function Set-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                "$($localizedData.NoDefaultDriveLetterMismatchMessage -f $NoDefaultDriveLetter)"
+                "$($localizedData.NoDefaultDriveLetterMismatchMessage -f $partition.NoDefaultDriveLetter, $NoDefaultDriveLetter)"
             ) -join '' )
 
         # setting the partition property NoDefaultDriveLetter to True to prevent adding drive letter on reboot

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -519,19 +519,20 @@ function Set-TargetResource
     } # if
 
     #get the current partition state for NoDefaultDriveLetter
-    $partition = $disk | Get-Partition -ErrorAction SilentlyContinue
+    $partition = $disk | Get-Partition |
+        Where-Object -Property AccessPaths -Contains -Value $AccessPath -ErrorAction SilentlyContinue
 
     if ($partition.NoDefaultDriveLetter -ne $NoDefaultDriveLetter)
     {
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                "$($localizedData.NoDefaultDriveLetterMismatchMessage -f $NoDefaultDriveLetter)"
+            ) -join '' )
+
         # setting the partition property NoDefaultDriveLetter to True to prevent adding drive letter on reboot
         Set-Partition -PartitionNumber $partition.PartitionNumber `
             -DiskNumber $disk.Number `
             -NoDefaultDriveLetter $NoDefaultDriveLetter
-
-        Write-Verbose -Message ( @(
-                "$($MyInvocation.MyCommand): "
-                $($localizedData.SuccessfullyInitializedMessage -f $AccessPath)
-            ) -join '' )
     } # if
 
 } # Set-TargetResource

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -27,6 +27,9 @@ $localizedData = Get-LocalizedData `
     .PARAMETER AccessPath
     Specifies the access path folder to the assign the disk volume to
 
+    .PARAMETER NoDefaultDriveLetter
+    Specifies the partition drive letter assignment behavior. Defaults to True.
+
     .PARAMETER DiskId
     Specifies the disk identifier for the disk to modify.
 
@@ -137,6 +140,9 @@ function Get-TargetResource
 
     .PARAMETER AccessPath
     Specifies the access path folder to the assign the disk volume to
+
+    .PARAMETER NoDefaultDriveLetter
+    Specifies the partition drive letter assignment behavior. Defaults to True.
 
     .PARAMETER DiskId
     Specifies the disk identifier for the disk to modify.
@@ -525,6 +531,9 @@ function Set-TargetResource
     .PARAMETER AccessPath
     Specifies the access path folder to the assign the disk volume to
 
+    .PARAMETER NoDefaultDriveLetter
+    Specifies the partition drive letter assignment behavior. Defaults to True.
+
     .PARAMETER DiskId
     Specifies the disk identifier for the disk to modify.
 
@@ -552,6 +561,10 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $AccessPath,
+
+        [Parameter()]
+        [System.Boolean]
+        $NoDefaultDriveLetter = $true,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -636,6 +649,17 @@ function Test-TargetResource
 
     # Get the partitions on the disk
     $partition = $disk | Get-Partition -ErrorAction SilentlyContinue
+
+    # Check if the partition NoDefaultDriveLetter parameter is correct
+
+    if ($partition.NoDefaultDriveLetter -ne $NoDefaultDriveLetter)
+    {
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($localizedData.NoDefaultDriveLetterMismatchMessage -f $NoDefaultDriveLetter)
+            ) -join '' )
+        return $false
+    } # if
 
     # Check if the disk has an existing partition assigned to the access path
     $assignedPartition = $partition |

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -28,7 +28,7 @@ $localizedData = Get-LocalizedData `
     Specifies the access path folder to the assign the disk volume to
 
     .PARAMETER NoDefaultDriveLetter
-    Specifies the partition drive letter assignment behavior. Defaults to True.
+    Prevents a default drive letter from being assigned to a newly created partition. Defaults to True.
 
     .PARAMETER DiskId
     Specifies the disk identifier for the disk to modify.
@@ -142,7 +142,7 @@ function Get-TargetResource
     Specifies the access path folder to the assign the disk volume to
 
     .PARAMETER NoDefaultDriveLetter
-    Specifies the partition drive letter assignment behavior. Defaults to True.
+    Prevents a default drive letter from being assigned to a newly created partition. Defaults to True.
 
     .PARAMETER DiskId
     Specifies the disk identifier for the disk to modify.
@@ -518,7 +518,7 @@ function Set-TargetResource
             ) -join '' )
     } # if
 
-    #get the current partition state for NoDefaultDriveLetter
+    # Get the current partition state for NoDefaultDriveLetter
     $assignedPartition = $partition |
         Where-Object -Property AccessPaths -Contains -Value $AccessPath
 
@@ -529,12 +529,11 @@ function Set-TargetResource
                     "$($localizedData.NoDefaultDriveLetterMismatchMessage -f $assignedPartition.NoDefaultDriveLetter, $NoDefaultDriveLetter)"
                 ) -join '' )
 
-            # setting the partition property NoDefaultDriveLetter to True to prevent adding drive letter on reboot
+            # Setting the partition property NoDefaultDriveLetter to True to prevent adding drive letter on reboot
             Set-Partition -PartitionNumber $assignedPartition.PartitionNumber `
                 -DiskNumber $disk.Number `
                 -NoDefaultDriveLetter $NoDefaultDriveLetter
         } # if
-
 } # Set-TargetResource
 
 <#
@@ -545,7 +544,7 @@ function Set-TargetResource
     Specifies the access path folder to the assign the disk volume to
 
     .PARAMETER NoDefaultDriveLetter
-    Specifies the partition drive letter assignment behavior. Defaults to True.
+    Prevents a default drive letter from being assigned to a newly created partition. Defaults to True.
 
     .PARAMETER DiskId
     Specifies the disk identifier for the disk to modify.
@@ -662,8 +661,6 @@ function Test-TargetResource
 
     # Get the partitions on the disk
     $partition = $disk | Get-Partition -ErrorAction SilentlyContinue
-
-
 
     # Check if the disk has an existing partition assigned to the access path
     $assignedPartition = $partition |

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.schema.mof
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.schema.mof
@@ -3,6 +3,7 @@
 class MSFT_DiskAccessPath : OMI_BaseResource
 {
     [Key, Description("Specifies the access path folder to the assign the disk volume to.")] String AccessPath;
+    [Write, Description("Specifies no automatic drive letter assignment to the partition: Defaults to True")] Boolean NoDefaultDriveLetter;
     [Required, Description("Specifies the disk identifier for the disk to modify.")] String DiskId;
     [Write, Description("Specifies the identifier type the DiskId contains. Defaults to Number."), ValueMap{"Number","UniqueId","Guid"}, Values{"Number","UniqueId","Guid"}] String DiskIdType;
     [Write, Description("Specifies the size of new volume.")] Uint64 Size;

--- a/DSCResources/MSFT_DiskAccessPath/en-us/MSFT_DiskAccessPath.strings.psd1
+++ b/DSCResources/MSFT_DiskAccessPath/en-us/MSFT_DiskAccessPath.strings.psd1
@@ -20,7 +20,7 @@
     DiskReadOnlyMessage = Disk with {0} '{1}'is readonly.
     DiskNotGPTMessage = Disk with {0} '{1}' is initialised with '{2}' partition style. GPT required.
     AccessPathNotFoundMessage = A volume assigned to access path '{0}' was not found.
-    NoDefaultDriveLetterMismatchMessage = Partition default drive assigmemt parameter '{0}' does not match '{1}'.
+    NoDefaultDriveLetterMismatchMessage = Partition default drive letter assigmemt parameter '{0}' does not match '{1}'.
     SizeMismatchMessage = Partition assigned to access path '{0}' has size {1}, which does not match expected size {2}.
     AllocationUnitSizeMismatchMessage = Volume assigned to access path '{0}' has allocation unit size {1} KB does not match expected allocation unit size {2} KB.
     FileSystemFormatMismatch = Volume assigned to access path '{0}' filesystem format '{1}' does not match expected format '{2}'.

--- a/DSCResources/MSFT_DiskAccessPath/en-us/MSFT_DiskAccessPath.strings.psd1
+++ b/DSCResources/MSFT_DiskAccessPath/en-us/MSFT_DiskAccessPath.strings.psd1
@@ -20,7 +20,7 @@
     DiskReadOnlyMessage = Disk with {0} '{1}'is readonly.
     DiskNotGPTMessage = Disk with {0} '{1}' is initialised with '{2}' partition style. GPT required.
     AccessPathNotFoundMessage = A volume assigned to access path '{0}' was not found.
-    NoDefaultDriveLetterMismatchMessage = Partition default drive assigmemt parameter does not match '{0}'.
+    NoDefaultDriveLetterMismatchMessage = Partition default drive assigmemt parameter '{0}' does not match '{1}'.
     SizeMismatchMessage = Partition assigned to access path '{0}' has size {1}, which does not match expected size {2}.
     AllocationUnitSizeMismatchMessage = Volume assigned to access path '{0}' has allocation unit size {1} KB does not match expected allocation unit size {2} KB.
     FileSystemFormatMismatch = Volume assigned to access path '{0}' filesystem format '{1}' does not match expected format '{2}'.

--- a/DSCResources/MSFT_DiskAccessPath/en-us/MSFT_DiskAccessPath.strings.psd1
+++ b/DSCResources/MSFT_DiskAccessPath/en-us/MSFT_DiskAccessPath.strings.psd1
@@ -20,6 +20,7 @@
     DiskReadOnlyMessage = Disk with {0} '{1}'is readonly.
     DiskNotGPTMessage = Disk with {0} '{1}' is initialised with '{2}' partition style. GPT required.
     AccessPathNotFoundMessage = A volume assigned to access path '{0}' was not found.
+    NoDefaultDriveLetterMismatchMessage = Partition default drive assigmemt parameter does not match '{0}'.
     SizeMismatchMessage = Partition assigned to access path '{0}' has size {1}, which does not match expected size {2}.
     AllocationUnitSizeMismatchMessage = Volume assigned to access path '{0}' has allocation unit size {1} KB does not match expected allocation unit size {2} KB.
     FileSystemFormatMismatch = Volume assigned to access path '{0}' filesystem format '{1}' does not match expected format '{2}'.

--- a/Tests/Integration/MSFT_DiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_DiskAccessPath.Integration.Tests.ps1
@@ -62,7 +62,7 @@ try
                                 @{
                                     NodeName   = 'localhost'
                                     AccessPath = $accessPathA
-                                    DiskId     = [int]$disk.Number
+                                    DiskId     = $disk.Number
                                     DiskIdType = 'Number'
                                     FSLabel    = $FSLabelA
                                     Size       = 100MB

--- a/Tests/Integration/MSFT_DiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_DiskAccessPath.Integration.Tests.ps1
@@ -62,7 +62,7 @@ try
                                 @{
                                     NodeName   = 'localhost'
                                     AccessPath = $accessPathA
-                                    DiskId     = $disk.Number
+                                    DiskId     = [int]$disk.Number
                                     DiskIdType = 'Number'
                                     FSLabel    = $FSLabelA
                                     Size       = 100MB

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -546,10 +546,6 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-Partition `
-                    -Verifiable
-
-                Mock `
                     -CommandName Get-Volume `
                     -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
@@ -560,6 +556,10 @@ try
 
                 Mock `
                     -CommandName Add-PartitionAccessPath `
+                    -Verifiable
+
+                    Mock `
+                    -CommandName Set-Partition `
                     -Verifiable
 
                 # mocks that should not be called
@@ -586,6 +586,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -616,10 +617,6 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-Partition `
-                    -Verifiable
-
-                Mock `
                     -CommandName Get-Volume `
                     -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
@@ -630,6 +627,10 @@ try
 
                 Mock `
                     -CommandName Add-PartitionAccessPath `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Partition `
                     -Verifiable
 
                 # mocks that should not be called
@@ -657,6 +658,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -687,10 +689,6 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-Partition `
-                    -Verifiable
-
-                Mock `
                     -CommandName Get-Volume `
                     -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
@@ -702,6 +700,11 @@ try
                 Mock `
                     -CommandName Add-PartitionAccessPath `
                     -Verifiable
+
+                Mock `
+                    -CommandName Set-Partition `
+                    -Verifiable
+
 
                 # mocks that should not be called
                 Mock -CommandName Initialize-Disk
@@ -728,6 +731,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -798,6 +802,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -832,10 +837,6 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-Partition `
-                    -Verifiable
-
-                Mock `
                     -CommandName Get-Volume `
                     -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
@@ -846,6 +847,10 @@ try
 
                 Mock `
                     -CommandName Add-PartitionAccessPath `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Partition `
                     -Verifiable
 
                 # mocks that should not be called
@@ -871,6 +876,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -901,10 +907,6 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-Partition `
-                    -Verifiable
-
-                Mock `
                     -CommandName Get-Volume `
                     -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
@@ -915,6 +917,10 @@ try
 
                 Mock `
                     -CommandName Add-PartitionAccessPath `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Partition `
                     -Verifiable
 
                 # mocks that should not be called
@@ -941,6 +947,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -967,10 +974,6 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-Partition `
-                    -Verifiable
-
-                Mock `
                     -CommandName Get-Volume `
                     -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
@@ -981,6 +984,10 @@ try
 
                 Mock `
                     -CommandName Add-PartitionAccessPath `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Partition `
                     -Verifiable
 
                 # mocks that should not be called
@@ -1008,6 +1015,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -546,6 +546,10 @@ try
                     -Verifiable
 
                 Mock `
+                    -CommandName Set-Partition `
+                    -Verifiable
+
+                Mock `
                     -CommandName Get-Volume `
                     -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
@@ -609,6 +613,10 @@ try
                 Mock `
                     -CommandName New-Partition `
                     -MockWith { $script:mockedPartitionNoAccess } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Partition `
                     -Verifiable
 
                 Mock `
@@ -679,6 +687,10 @@ try
                     -Verifiable
 
                 Mock `
+                    -CommandName Set-Partition `
+                    -Verifiable
+
+                Mock `
                     -CommandName Get-Volume `
                     -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
@@ -743,6 +755,10 @@ try
                 Mock `
                     -CommandName New-Partition `
                     -MockWith { $script:mockedPartitionNoAccess } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Partition `
                     -Verifiable
 
                 Mock `
@@ -816,6 +832,10 @@ try
                     -Verifiable
 
                 Mock `
+                    -CommandName Set-Partition `
+                    -Verifiable
+
+                Mock `
                     -CommandName Get-Volume `
                     -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
@@ -881,6 +901,10 @@ try
                     -Verifiable
 
                 Mock `
+                    -CommandName Set-Partition `
+                    -Verifiable
+
+                Mock `
                     -CommandName Get-Volume `
                     -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
@@ -940,6 +964,10 @@ try
                 Mock `
                     -CommandName New-Partition `
                     -MockWith { $script:mockedPartition } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Partition `
                     -Verifiable
 
                 Mock `

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -104,7 +104,7 @@ try
             NoDefaultDriveLetter = $true
         }
 
-        $script:mockedPartitionNDefaultDriveLetter = [pscustomobject] @{
+        $script:mockedPartitionNoDefaultDriveLetter = [pscustomobject] @{
             AccessPaths     = @(
                 '\\?\Volume{2d313fdd-e4a4-4f31-9784-dad758e0030f}\'
                 $script:testAccessPath
@@ -985,7 +985,7 @@ try
 
                 Mock `
                     -CommandName New-Partition `
-                    -MockWith { $script:mockedPartitionNDefaultDriveLetter } `
+                    -MockWith { $script:mockedPartitionNoDefaultDriveLetter } `
                     -Verifiable
 
                 Mock `

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -1889,6 +1889,62 @@ try
                 }
             }
 
+            Context 'Test mismatching NoDefaultDriveLetter using Disk Number' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Assert-AccessPathValid `
+                    -MockWith { $script:testAccessPath } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' } `
+                    -MockWith { $script:mockedDisk0 } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Partition `
+                    -MockWith { $script:mockedPartitionNoDefaultDriveLetter } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolume } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -MockWith { $script:mockedCim } `
+                    -Verifiable
+
+                $script:result = $null
+
+                It 'Should not throw an exception' {
+                    {
+                        $script:result = Test-TargetResource `
+                            -DiskId $script:mockedDisk0.Number `
+                            -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
+                            -FSLabel 'myLabel' `
+                            -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should return false' {
+                    $script:result | Should -Be $false
+                }
+
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMock
+                    Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                        -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
+                    Assert-MockCalled -CommandName Get-Partition -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Times 1
+                    Assert-MockCalled -CommandName Get-CimInstance -Times 1
+                }
+            }
+
             Context 'Test all disk properties matching using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -101,7 +101,7 @@ try
             Size                 = $script:mockedPartitionSize
             PartitionNumber      = 1
             Type                 = 'Basic'
-            NoDefaultDriveLetter = $false
+            NoDefaultDriveLetter = $true
         }
 
         $script:mockedPartitionNoAccess = [pscustomobject] @{

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -532,7 +532,7 @@ try
 
         #region Function Set-TargetResource
         Describe 'MSFT_DiskAccessPath\Set-TargetResource' {
-            Context 'Offline GPT disk using Disk Number' {
+            Context 'Offline GPT disk using Disk Number with NoDefaultDriveLetter set to False' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Assert-AccessPathValid `
@@ -571,7 +571,7 @@ try
                     -CommandName Add-PartitionAccessPath `
                     -Verifiable
 
-                    Mock `
+                Mock `
                     -CommandName Set-Partition `
                     -Verifiable
 
@@ -603,7 +603,7 @@ try
                 }
             }
 
-            Context 'Offline GPT disk using Disk Unique Id' {
+            Context 'Offline GPT disk using Disk Unique Id with NoDefaultDriveLetter set to False' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Assert-AccessPathValid `
@@ -1187,7 +1187,7 @@ try
                 }
             }
 
-            Context 'Online GPT disk with partition/volume already assigned using Disk Number' {
+            Context 'Online GPT disk with partition/volume already assigned using Disk Number with NoDefaultDriveLetter set to False' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Assert-AccessPathValid `
@@ -1306,7 +1306,7 @@ try
                 }
             }
 
-            Context 'Online GPT disk containing matching partition but not assigned using Disk Number with no size parameter specified' {
+            Context 'Online GPT disk containing matching partition but not assigned using Disk Number with no size parameter specified with NoDefaultDriveLetter set to False' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Assert-AccessPathValid `

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -33,6 +33,7 @@ try
         $script:testDiskUniqueId = 'TESTDISKUNIQUEID'
         $script:testDiskGptGuid = [guid]::NewGuid()
         $script:testDiskMbrGuid = '123456'
+        $script:NoDefaultDriveLetter = $true
 
         $script:mockedDisk0 = [pscustomobject] @{
             Number         = $script:testDiskNumber
@@ -1670,6 +1671,7 @@ try
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
                             -AllocationUnitSize 4096 `
                             -Size 124 `
                             -Verbose
@@ -1724,6 +1726,7 @@ try
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
                             -AllocationUnitSize 4097 `
                             -Verbose
                     } | Should -Not -Throw
@@ -1780,6 +1783,7 @@ try
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
                             -FSFormat 'ReFS' `
                             -Verbose
                     } | Should -Not -Throw
@@ -1835,6 +1839,7 @@ try
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
                             -FSLabel 'NewLabel' `
                             -Verbose
                     } | Should -Not -Throw
@@ -1890,6 +1895,7 @@ try
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
                             -AllocationUnitSize 4096 `
                             -Size $script:mockedPartition.Size `
                             -FSFormat $script:mockedVolume.FileSystem `

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -108,6 +108,7 @@ try
         $script:mockedPartitionNoAccess = [pscustomobject] @{
             AccessPaths     = @(
                 '\\?\Volume{2d313fdd-e4a4-4f31-9784-dad758e0030f}\'
+                $script:testAccessPath
             )
             Size            = $script:mockedPartitionSize
             PartitionNumber = 1
@@ -590,6 +591,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -662,6 +664,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -734,6 +737,8 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
+
                 }
             }
 
@@ -804,6 +809,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -877,6 +883,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -947,6 +954,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -1015,6 +1023,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -1281,6 +1290,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 0
                     Assert-MockCalled -CommandName Format-Volume -Times 0
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -1339,6 +1349,7 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 0
                     Assert-MockCalled -CommandName Format-Volume -Times 0
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -112,6 +112,7 @@ try
             Size            = $script:mockedPartitionSize
             PartitionNumber = 1
             Type            = 'Basic'
+            NoDefaultDriveLetter = $script:NoDefaultDriveLetter
         }
 
         $script:mockedVolume = [pscustomobject] @{
@@ -589,7 +590,6 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -645,6 +645,7 @@ try
                             -DiskId $script:mockedDisk0Offline.UniqueId `
                             -DiskIdType 'UniqueId' `
                             -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
                             -Verbose
                     } | Should -Not -Throw
                 }
@@ -661,7 +662,6 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -734,7 +734,6 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -805,7 +804,6 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -879,7 +877,6 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -950,7 +947,6 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 
@@ -1002,6 +998,7 @@ try
                         Set-targetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
                             -Verbose
                     } | Should -Not -Throw
                 }
@@ -1018,7 +1015,6 @@ try
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
             }
 

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -87,6 +87,7 @@ try
             IsOffline      = $false
             IsReadOnly     = $false
             PartitionStyle = 'Raw'
+            NoDefaultDriveLetter = $true
         }
 
         $script:mockedCim = [pscustomobject] @{BlockSize = 4096}
@@ -98,9 +99,10 @@ try
                 '\\?\Volume{2d313fdd-e4a4-4f31-9784-dad758e0030f}\'
                 $script:testAccessPath
             )
-            Size            = $script:mockedPartitionSize
-            PartitionNumber = 1
-            Type            = 'Basic'
+            Size                 = $script:mockedPartitionSize
+            PartitionNumber      = 1
+            Type                 = 'Basic'
+            NoDefaultDriveLetter = $script:NoDefaultDriveLetter
         }
 
         $script:mockedPartitionNoAccess = [pscustomobject] @{

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -87,7 +87,6 @@ try
             IsOffline      = $false
             IsReadOnly     = $false
             PartitionStyle = 'Raw'
-            NoDefaultDriveLetter = $true
         }
 
         $script:mockedCim = [pscustomobject] @{BlockSize = 4096}
@@ -102,7 +101,7 @@ try
             Size                 = $script:mockedPartitionSize
             PartitionNumber      = 1
             Type                 = 'Basic'
-            NoDefaultDriveLetter = $script:NoDefaultDriveLetter
+            NoDefaultDriveLetter = $false
         }
 
         $script:mockedPartitionNoAccess = [pscustomobject] @{
@@ -113,7 +112,7 @@ try
             Size            = $script:mockedPartitionSize
             PartitionNumber = 1
             Type            = 'Basic'
-            NoDefaultDriveLetter = $script:NoDefaultDriveLetter
+            NoDefaultDriveLetter = $false
         }
 
         $script:mockedVolume = [pscustomobject] @{
@@ -565,6 +564,7 @@ try
 
                     Mock `
                     -CommandName Set-Partition `
+
                     -Verifiable
 
                 # mocks that should not be called

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -104,6 +104,16 @@ try
             NoDefaultDriveLetter = $true
         }
 
+        $script:mockedPartitionNDefaultDriveLetter = [pscustomobject] @{
+            AccessPaths     = @(
+                '\\?\Volume{2d313fdd-e4a4-4f31-9784-dad758e0030f}\'
+                $script:testAccessPath
+            )
+            Size                 = $script:mockedPartitionSize
+            PartitionNumber      = 1
+            Type                 = 'Basic'
+            NoDefaultDriveLetter = $false
+        }
         $script:mockedPartitionNoAccess = [pscustomobject] @{
             AccessPaths     = @(
                 '\\?\Volume{2d313fdd-e4a4-4f31-9784-dad758e0030f}\'
@@ -975,7 +985,7 @@ try
 
                 Mock `
                     -CommandName New-Partition `
-                    -MockWith { $script:mockedPartition } `
+                    -MockWith { $script:mockedPartitionNDefaultDriveLetter } `
                     -Verifiable
 
                 Mock `

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -101,13 +101,12 @@ try
             Size                 = $script:mockedPartitionSize
             PartitionNumber      = 1
             Type                 = 'Basic'
-            NoDefaultDriveLetter = $false
+            NoDefaultDriveLetter = $True
         }
 
         $script:mockedPartitionNoAccess = [pscustomobject] @{
             AccessPaths     = @(
                 '\\?\Volume{2d313fdd-e4a4-4f31-9784-dad758e0030f}\'
-                $script:testAccessPath
             )
             Size            = $script:mockedPartitionSize
             PartitionNumber = 1
@@ -1260,6 +1259,10 @@ try
                     -CommandName Add-PartitionAccessPath `
                     -Verifiable
 
+                Mock `
+                    -CommandName Set-Partition `
+                    -Verifiable
+
                 # mocks that should not be called
                 Mock -CommandName Set-Disk
                 Mock -CommandName Initialize-Disk
@@ -1318,6 +1321,10 @@ try
 
                 Mock `
                     -CommandName Add-PartitionAccessPath `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Partition `
                     -Verifiable
 
                 # mocks that should not be called

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -1935,8 +1935,6 @@ try
                     Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
                     Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 1
                 }
             }
 

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -1907,11 +1907,6 @@ try
                     -MockWith { $script:mockedPartitionNoDefaultDriveLetter } `
                     -Verifiable
 
-                Mock `
-                    -CommandName Get-Volume `
-                    -MockWith { $script:mockedVolume } `
-                    -Verifiable
-
                 $script:result = $null
 
                 It 'Should not throw an exception' {

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -101,7 +101,7 @@ try
             Size                 = $script:mockedPartitionSize
             PartitionNumber      = 1
             Type                 = 'Basic'
-            NoDefaultDriveLetter = $True
+            NoDefaultDriveLetter = $false
         }
 
         $script:mockedPartitionNoAccess = [pscustomobject] @{

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -1912,11 +1912,6 @@ try
                     -MockWith { $script:mockedVolume } `
                     -Verifiable
 
-                Mock `
-                    -CommandName Get-CimInstance `
-                    -MockWith { $script:mockedCim } `
-                    -Verifiable
-
                 $script:result = $null
 
                 It 'Should not throw an exception' {

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -1207,6 +1207,7 @@ try
                         Set-targetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
                             -Verbose
                     } | Should -Not -Throw
                 }
@@ -1264,6 +1265,7 @@ try
                         Set-targetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
                             -Size $script:mockedPartitionSize `
                             -Verbose
                     } | Should -Not -Throw
@@ -1322,6 +1324,7 @@ try
                         Set-targetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
                             -Verbose
                     } | Should -Not -Throw
                 }
@@ -1380,6 +1383,7 @@ try
                         Set-targetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
+                            -NoDefaultDriveLetter $script:NoDefaultDriveLetter `
                             -FSLabel 'NewLabel' `
                             -Verbose
                     } | Should -Not -Throw

--- a/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_DiskAccessPath.Tests.ps1
@@ -564,7 +564,6 @@ try
 
                     Mock `
                     -CommandName Set-Partition `
-
                     -Verifiable
 
                 # mocks that should not be called


### PR DESCRIPTION

#### Pull Request (PR) description

- DiskAccessPath
  Update the resource to not assign a drive letter by default when adding
  a disk access path. Adding a Set-Partition -NoDefaultDriveLetter $NoDefaultDriveLetter block
  defaulting to true. When adding access paths the disks will no longer have
  drive letters automatically assigned on next reboot which is the desired
  behavior.

#### This Pull Request (PR) fixes the following issues

 
 - Fixes [Issue #145](https://github.com/PowerShell/StorageDsc/issues/145).

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [x ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/storagedsc/187)
<!-- Reviewable:end -->
