### PR TITLE
MSFT_Disk: Implement workaround for maximum size discrepancy (fixes #181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   [Issue #191](https://github.com/PowerShell/StorageDsc/issues/191).
 - Correct unit tests for DiskAccessPath to test exact number of
   mocks called - fixes [Issue #199](https://github.com/PowerShell/StorageDsc/issues/199).
+- Maximum size calculation now uses workaround so that
+  Test-TargetResource works properly - workaround for
+  [Issue #181](https://github.com/PowerShell/StorageDsc/issues/181).
 
 ## 4.5.0.0
 

--- a/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
+++ b/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
@@ -816,7 +816,14 @@ function Test-TargetResource
     {
         $supportedSize = ($partition | Get-PartitionSupportedSize)
 
-        $Size = $supportedSize.SizeMax
+        $Size = if ($supportedSize.SizeMax - $partition.Size -lt 1MB)
+        {
+            $partition.Size
+        }
+        else
+        {
+            $supportedSize.SizeMax
+        }
     }
 
     if ($Size)

--- a/Tests/Integration/MSFTDSC_Disk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFTDSC_Disk.Integration.Tests.ps1
@@ -968,7 +968,6 @@ try
                                     DiskIdType     = 'Number'
                                     PartitionStyle = 'GPT'
                                     FSLabel        = $FSLabelA
-                                    Size           = 100MB
                                 }
                             )
                         }

--- a/Tests/Unit/MSFTDSC_Disk.Tests.ps1
+++ b/Tests/Unit/MSFTDSC_Disk.Tests.ps1
@@ -2728,7 +2728,7 @@ try
                     -MockWith {
                         return @{
                             SizeMin = 0
-                            SizeMax = $script:mockedPartition.Size + 1024
+                            SizeMax = $script:mockedPartition.Size + 1.1mb
                         }
                     } `
                     -Verifiable


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description

This PR introduces a workaround that fixes issue #181 where the reported maximum supported size of a partition would be approximately 1MB bigger than the actual size of the partition. As long as it is unclear why the New-Partition and Get-PartitionSupportedSize cmdlets report different data if neither Offset nor Alignment parameters are used, this workaround should remain in place.

If this is not the case, Test-TargetResource for a disk configured to use the remaining size will always return false and trigger an endless cycle of LCM runs.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
- Fixes #181

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/storagedsc/197)
<!-- Reviewable:end -->
