### PR TITLE
DiskAccessPath Add Disk Subsystem Refresh before set - Fixes #121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Refactored tests for `StorageDsc.Common` to meet latest standards.
 - Minor style corrections.
 - Removed unused localization strings from resources.
+- DiskAccessPath:
+  - Added function to force refresh of disk subsystem at the start of
+    Set-TargetResource to prevent errors occuring when the disk access
+    path is already assigned - See [Issue 121](https://github.com/PowerShell/StorageDsc/issues/121)
 
 ## 4.7.0.0
 

--- a/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
+++ b/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
@@ -10,45 +10,45 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFTDSC_Disk'
 
 <#
     .SYNOPSIS
-    Returns the current state of the Disk and Partition.
+        Returns the current state of the Disk and Partition.
 
     .PARAMETER DriveLetter
-    Specifies the preferred letter to assign to the disk volume.
+        Specifies the preferred letter to assign to the disk volume.
 
     .PARAMETER DiskId
-    Specifies the disk identifier for the disk to modify.
+        Specifies the disk identifier for the disk to modify.
 
     .PARAMETER DiskIdType
-    Specifies the identifier type the DiskId contains. Defaults to Number.
+        Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER PartitionStyle
-    Specifies the partition style of the disk. Defaults to GPT.
-    This parameter is not used in Get-TargetResource.
+        Specifies the partition style of the disk. Defaults to GPT.
+        This parameter is not used in Get-TargetResource.
 
     .PARAMETER Size
-    Specifies the size of new volume (use all available space on disk if not provided).
-    This parameter is not used in Get-TargetResource.
+        Specifies the size of new volume (use all available space on disk if not provided).
+        This parameter is not used in Get-TargetResource.
 
     .PARAMETER FSLabel
-    Specifies the volume label to assign to the volume.
-    This parameter is not used in Get-TargetResource.
+        Specifies the volume label to assign to the volume.
+        This parameter is not used in Get-TargetResource.
 
     .PARAMETER AllocationUnitSize
-    Specifies the allocation unit size to use when formatting the volume.
-    This parameter is not used in Get-TargetResource.
+        Specifies the allocation unit size to use when formatting the volume.
+        This parameter is not used in Get-TargetResource.
 
     .PARAMETER FSFormat
-    Specifies the file system format of the new volume.
-    This parameter is not used in Get-TargetResource.
+        Specifies the file system format of the new volume.
+        This parameter is not used in Get-TargetResource.
 
     .PARAMETER AllowDestructive
-    Specifies if potentially destructive operations may occur.
-    This parameter is not used in Get-TargetResource.
+        Specifies if potentially destructive operations may occur.
+        This parameter is not used in Get-TargetResource.
 
     .PARAMETER ClearDisk
-    Specifies if the disks partition schema should be removed entirely, even if data and OEM
-    partitions are present. Only possible with AllowDestructive enabled.
-    This parameter is not used in Get-TargetResource.
+        Specifies if the disks partition schema should be removed entirely, even if data and OEM
+        partitions are present. Only possible with AllowDestructive enabled.
+        This parameter is not used in Get-TargetResource.
 #>
 function Get-TargetResource
 {
@@ -139,38 +139,38 @@ function Get-TargetResource
 
 <#
     .SYNOPSIS
-    Initializes the Disk and Partition and assigns the drive letter.
+        Initializes the Disk and Partition and assigns the drive letter.
 
     .PARAMETER DriveLetter
-    Specifies the preferred letter to assign to the disk volume.
+        Specifies the preferred letter to assign to the disk volume.
 
     .PARAMETER DiskId
-    Specifies the disk identifier for the disk to modify.
+        Specifies the disk identifier for the disk to modify.
 
     .PARAMETER DiskIdType
-    Specifies the identifier type the DiskId contains. Defaults to Number.
+        Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER PartitionStyle
-    Specifies the partition style of the disk. Defaults to GPT.
+        Specifies the partition style of the disk. Defaults to GPT.
 
     .PARAMETER Size
-    Specifies the size of new volume. Leave empty to use the remaining free space.
+        Specifies the size of new volume. Leave empty to use the remaining free space.
 
     .PARAMETER FSLabel
-    Specifies the volume label to assign to the volume.
+        Specifies the volume label to assign to the volume.
 
     .PARAMETER AllocationUnitSize
-    Specifies the allocation unit size to use when formatting the volume.
+        Specifies the allocation unit size to use when formatting the volume.
 
     .PARAMETER FSFormat
-    Specifies the file system format of the new volume.
+        Specifies the file system format of the new volume.
 
     .PARAMETER AllowDestructive
-    Specifies if potentially destructive operations may occur.
+        Specifies if potentially destructive operations may occur.
 
     .PARAMETER ClearDisk
-    Specifies if the disks partition schema should be removed entirely, even if data and OEM
-    partitions are present. Only possible with AllowDestructive enabled.
+        Specifies if the disks partition schema should be removed entirely, even if data and OEM
+        partitions are present. Only possible with AllowDestructive enabled.
 #>
 function Set-TargetResource
 {
@@ -637,38 +637,38 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-    Tests if the disk is initialized, the partion exists and the drive letter is assigned.
+        Tests if the disk is initialized, the partion exists and the drive letter is assigned.
 
     .PARAMETER DriveLetter
-    Specifies the preferred letter to assign to the disk volume.
+        Specifies the preferred letter to assign to the disk volume.
 
     .PARAMETER DiskId
-    Specifies the disk identifier for the disk to modify.
+        Specifies the disk identifier for the disk to modify.
 
     .PARAMETER DiskIdType
-    Specifies the identifier type the DiskId contains. Defaults to Number.
+        Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER PartitionStyle
-    Specifies the partition style of the disk. Defaults to GPT.
+        Specifies the partition style of the disk. Defaults to GPT.
 
     .PARAMETER Size
-    Specifies the size of new volume. Leave empty to use the remaining free space.
+        Specifies the size of new volume. Leave empty to use the remaining free space.
 
     .PARAMETER FSLabel
-    Specifies the volume label to assign to the volume.
+        Specifies the volume label to assign to the volume.
 
     .PARAMETER AllocationUnitSize
-    Specifies the allocation unit size to use when formatting the volume.
+        Specifies the allocation unit size to use when formatting the volume.
 
     .PARAMETER FSFormat
-    Specifies the file system format of the new volume.
+        Specifies the file system format of the new volume.
 
     .PARAMETER AllowDestructive
-    Specifies if potentially destructive operations may occur.
+        Specifies if potentially destructive operations may occur.
 
     .PARAMETER ClearDisk
-    Specifies if the disks partition schema should be removed entirely, even if data and OEM
-    partitions are present. Only possible with AllowDestructive enabled.
+        Specifies if the disks partition schema should be removed entirely, even if data and OEM
+        partitions are present. Only possible with AllowDestructive enabled.
 #>
 function Test-TargetResource
 {

--- a/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
+++ b/DSCResources/MSFT_DiskAccessPath/MSFT_DiskAccessPath.psm1
@@ -10,31 +10,31 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_DiskAccessPath'
 
 <#
     .SYNOPSIS
-    Returns the current state of the Disk and Partition.
+        Returns the current state of the Disk and Partition.
 
     .PARAMETER AccessPath
-    Specifies the access path folder to the assign the disk volume to
+        Specifies the access path folder to the assign the disk volume to
 
     .PARAMETER NoDefaultDriveLetter
-    Prevents a default drive letter from being assigned to a newly created partition. Defaults to True.
+        Prevents a default drive letter from being assigned to a newly created partition. Defaults to True.
 
     .PARAMETER DiskId
-    Specifies the disk identifier for the disk to modify.
+        Specifies the disk identifier for the disk to modify.
 
     .PARAMETER DiskIdType
-    Specifies the identifier type the DiskId contains. Defaults to Number.
+        Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER Size
-    Specifies the size of new volume (use all available space on disk if not provided).
+        Specifies the size of new volume (use all available space on disk if not provided).
 
     .PARAMETER FSLabel
-    Specifies the volume label to assign to the volume.
+        Specifies the volume label to assign to the volume.
 
     .PARAMETER AllocationUnitSize
-    Specifies the allocation unit size to use when formatting the volume.
+        Specifies the allocation unit size to use when formatting the volume.
 
     .PARAMETER FSFormat
-    Specifies the file system format of the new volume.
+        Specifies the file system format of the new volume.
 #>
 function Get-TargetResource
 {
@@ -125,31 +125,31 @@ function Get-TargetResource
 
 <#
     .SYNOPSIS
-    Initializes the Disk and Partition and assigns the access path.
+        Initializes the Disk and Partition and assigns the access path.
 
     .PARAMETER AccessPath
-    Specifies the access path folder to the assign the disk volume to
+        Specifies the access path folder to the assign the disk volume to
 
     .PARAMETER NoDefaultDriveLetter
-    Prevents a default drive letter from being assigned to a newly created partition. Defaults to True.
+        Prevents a default drive letter from being assigned to a newly created partition. Defaults to True.
 
     .PARAMETER DiskId
-    Specifies the disk identifier for the disk to modify.
+        Specifies the disk identifier for the disk to modify.
 
     .PARAMETER DiskIdType
-    Specifies the identifier type the DiskId contains. Defaults to Number.
+        Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER Size
-    Specifies the size of new volume (use all available space on disk if not provided).
+        Specifies the size of new volume (use all available space on disk if not provided).
 
     .PARAMETER FSLabel
-    Specifies the volume label to assign to the volume.
+        Specifies the volume label to assign to the volume.
 
     .PARAMETER AllocationUnitSize
-    Specifies the allocation unit size to use when formatting the volume.
+        Specifies the allocation unit size to use when formatting the volume.
 
     .PARAMETER FSFormat
-    Specifies the file system format of the new volume.
+        Specifies the file system format of the new volume.
 #>
 function Set-TargetResource
 {
@@ -538,31 +538,31 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-    Tests if the disk is initialized, the partion exists and the access path is assigned.
+        Tests if the disk is initialized, the partion exists and the access path is assigned.
 
     .PARAMETER AccessPath
-    Specifies the access path folder to the assign the disk volume to
+        Specifies the access path folder to the assign the disk volume to
 
     .PARAMETER NoDefaultDriveLetter
-    Prevents a default drive letter from being assigned to a newly created partition. Defaults to True.
+        Prevents a default drive letter from being assigned to a newly created partition. Defaults to True.
 
     .PARAMETER DiskId
-    Specifies the disk identifier for the disk to modify.
+        Specifies the disk identifier for the disk to modify.
 
     .PARAMETER DiskIdType
-    Specifies the identifier type the DiskId contains. Defaults to Number.
+        Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER Size
-    Specifies the size of new volume (use all available space on disk if not provided).
+        Specifies the size of new volume (use all available space on disk if not provided).
 
     .PARAMETER FSLabel
-    Specifies the volume label to assign to the volume.
+        Specifies the volume label to assign to the volume.
 
     .PARAMETER AllocationUnitSize
-    Specifies the allocation unit size to use when formatting the volume.
+        Specifies the allocation unit size to use when formatting the volume.
 
     .PARAMETER FSFormat
-    Specifies the file system format of the new volume.
+        Specifies the file system format of the new volume.
 #>
 function Test-TargetResource
 {
@@ -758,25 +758,25 @@ function Test-TargetResource
 
 <#
     .SYNOPSIS
-    Check access path is found in PSDrives.
+        Check access path is found in PSDrives.
 
     .DESCRIPTION
-    Check if the access path is found in the list of PSDrives and if not
-    then forces a full refresh of the list and searches that.
+        Check if the access path is found in the list of PSDrives and if not
+        then forces a full refresh of the list and searches that.
 
     .PARAMETER AccessPath
-    Specifies the access path folder.
+        Specifies the access path folder.
 
     .NOTES
-    The full refresh of PSDrive wihtout any parameters is required because
-    this is the only way to completely force a refresh of disks and other
-    related CIM objects.
+        The full refresh of PSDrive without any parameters is required because
+        this is the only way to completely force a refresh of disks and other
+        related CIM objects.
 
-    If the refresh is not forced then there is a risk that the drive will
-    appear to not be mounted, causing an error when the resource attempts
-    to remount it.
+        If the refresh is not forced then there is a risk that the drive will
+        appear to not be mounted, causing an error when the resource attempts
+        to remount it.
 
-    See https://github.com/PowerShell/StorageDsc/issues/121
+        See https://github.com/PowerShell/StorageDsc/issues/121
 #>
 function Test-AccessPathInPSDrive
 {
@@ -794,7 +794,7 @@ function Test-AccessPathInPSDrive
         $accessPathDisk = $AccessPath.Split(':')[0]
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.CheckingPSDriveMessage -f $AccessPath, $accessPathDisk)
+                $($script:localizedData.CheckingPSDriveMessage -f $AccessPath, $accessPathDisk)
             ) -join '' )
 
         $accessPathDrive = Get-PSDrive -Name $accessPathDisk -ErrorAction Stop
@@ -803,14 +803,31 @@ function Test-AccessPathInPSDrive
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.UnavailablePSDriveMessage -f $AccessPath, $accessPathDisk)
+                $($script:localizedData.UnavailablePSDriveMessage -f $AccessPath, $accessPathDisk)
             ) -join '' )
 
         $accessPathDrive = Get-PSDrive
         $accessPathDrive = $accessPathDrive | Where-Object -Property Name -eq $accessPathDisk
     }
 
-    return ($null -ne $accessPathDrive)
+    $accessPathFound = ($null -ne $accessPathDrive)
+
+    if ($accessPathFound)
+    {
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.PSDriveFoundMessage -f $AccessPath, $accessPathDisk)
+            ) -join '' )
+    }
+    else
+    {
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.PSDriveNotFoundMessage -f $AccessPath, $accessPathDisk)
+            ) -join '' )
+    }
+
+    return $accessPathFound
 } # Test-AccessPathInPSDrive
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_DiskAccessPath/en-US/MSFT_DiskAccessPath.strings.psd1
+++ b/DSCResources/MSFT_DiskAccessPath/en-US/MSFT_DiskAccessPath.strings.psd1
@@ -32,6 +32,8 @@
     AccessPathNotFoundOnPartitionMessage = Disk with {0} '{1}' does not contain a partition assigned to access path '{2}'.
     CheckingPSDriveMessage = Checking access path '{0}' is available as PSDrive '{1}'.
     UnavailablePSDriveMessage = Access path '{0}' is unavailable as PSDrive '{1}', refreshing PSDrives list.
+    PSDriveFoundMessage = Access path '{0}' found as PSDrive '{1}'.
+    PSDriveNotFoundMessage = Access path '{0}' not found as PSDrive '{1}'.
     DiskAlreadyInitializedError = Disk with {0} '{1}' is already initialized with {2}.
     NewParitionIsReadOnlyError = New partition '{2}' on disk with {0} '{1}' did not become writable in the expected time.
 '@

--- a/DSCResources/MSFT_DiskAccessPath/en-US/MSFT_DiskAccessPath.strings.psd1
+++ b/DSCResources/MSFT_DiskAccessPath/en-US/MSFT_DiskAccessPath.strings.psd1
@@ -30,7 +30,8 @@
     VolumeFoundMessage = Found {3} volume not assigned to path on partition '{2}' disk with {0} '{1}'.
     MatchingPartitionFoundMessage = Disk with {0} '{1}' already contains paritions, and partition '{2}' matches required size.
     AccessPathNotFoundOnPartitionMessage = Disk with {0} '{1}' does not contain a partition assigned to access path '{2}'.
-
+    CheckingPSDriveMessage = Checking access path '{0}' is available as PSDrive '{1}'.
+    UnavailablePSDriveMessage = Access path '{0}' is unavailable as PSDrive '{1}', refreshing PSDrives list.
     DiskAlreadyInitializedError = Disk with {0} '{1}' is already initialized with {2}.
     NewParitionIsReadOnlyError = New partition '{2}' on disk with {0} '{1}' did not become writable in the expected time.
 '@

--- a/DSCResources/MSFT_MountImage/MSFT_MountImage.psm1
+++ b/DSCResources/MSFT_MountImage/MSFT_MountImage.psm1
@@ -10,10 +10,10 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_MountImage'
 
 <#
     .SYNOPSIS
-    Returns the current mount state of the VHD or ISO file.
+        Returns the current mount state of the VHD or ISO file.
 
     .PARAMETER ImagePath
-    Specifies the path of the VHD or ISO file.
+        Specifies the path of the VHD or ISO file.
 #>
 function Get-TargetResource
 {
@@ -85,22 +85,22 @@ function Get-TargetResource
 
 <#
     .SYNOPSIS
-    Mounts or dismounts the ISO or VHD.
+        Mounts or dismounts the ISO or VHD.
 
     .PARAMETER ImagePath
-    Specifies the path of the VHD or ISO file.
+        Specifies the path of the VHD or ISO file.
 
     .PARAMETER DriveLetter
-    Specifies the drive letter to mount this VHD or ISO to.
+        Specifies the drive letter to mount this VHD or ISO to.
 
     .PARAMETER StorageType
-    Specifies the storage type of a file. If the StorageType parameter is not specified, then the storage type is determined by file extension.
+        Specifies the storage type of a file. If the StorageType parameter is not specified, then the storage type is determined by file extension.
 
     .PARAMETER Access
-    Allows a VHD file to be mounted in read-only or read-write mode. ISO files are mounted in read-only mode regardless of what parameter value you provide.
+        Allows a VHD file to be mounted in read-only or read-write mode. ISO files are mounted in read-only mode regardless of what parameter value you provide.
 
     .PARAMETER Ensure
-    Determines whether the setting should be applied or removed.
+        Determines whether the setting should be applied or removed.
 #>
 function Set-TargetResource
 {
@@ -225,22 +225,24 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-    Tests if the ISO or VHD file mount is in the correct state.
+        Tests if the ISO or VHD file mount is in the correct state.
 
     .PARAMETER ImagePath
-    Specifies the path of the VHD or ISO file.
+        Specifies the path of the VHD or ISO file.
 
     .PARAMETER DriveLetter
-    Specifies the drive letter to mount this VHD or ISO to.
+        Specifies the drive letter to mount this VHD or ISO to.
 
     .PARAMETER StorageType
-    Specifies the storage type of a file. If the StorageType parameter is not specified, then the storage type is determined by file extension.
+        Specifies the storage type of a file. If the StorageType parameter is not
+        specified, then the storage type is determined by file extension.
 
     .PARAMETER Access
-    Allows a VHD file to be mounted in read-only or read-write mode. ISO files are mounted in read-only mode regardless of what parameter value you provide.
+        Allows a VHD file to be mounted in read-only or read-write mode. ISO files
+        are mounted in read-only mode regardless of what parameter value you provide.
 
     .PARAMETER Ensure
-    Determines whether the setting should be applied or removed.
+        Determines whether the setting should be applied or removed.
 #>
 function Test-TargetResource
 {
@@ -364,27 +366,29 @@ function Test-TargetResource
 
 <#
     .SYNOPSIS
-    Validates that the parameters passed are valid. If the parameter combination
-    is invalid then an exception will be thrown. Also validates the DriveLetter
-    value that is passed is valid.
+        Validates that the parameters passed are valid. If the parameter combination
+        is invalid then an exception will be thrown. Also validates the DriveLetter
+        value that is passed is valid.
 
     .PARAMETER ImagePath
-    Specifies the path of the VHD or ISO file.
+        Specifies the path of the VHD or ISO file.
 
     .PARAMETER DriveLetter
-    Specifies the drive letter to mount this VHD or ISO to.
+        Specifies the drive letter to mount this VHD or ISO to.
 
     .PARAMETER StorageType
-    Specifies the storage type of a file. If the StorageType parameter is not specified, then the storage type is determined by file extension.
+        Specifies the storage type of a file. If the StorageType parameter is not
+        specified, then the storage type is determined by file extension.
 
     .PARAMETER Access
-    Allows a VHD file to be mounted in read-only or read-write mode. ISO files are mounted in read-only mode regardless of what parameter value you provide.
+        Allows a VHD file to be mounted in read-only or read-write mode. ISO files
+        are mounted in read-only mode regardless of what parameter value you provide.
 
     .PARAMETER Ensure
-    Determines whether the setting should be applied or removed.
+        Determines whether the setting should be applied or removed.
 
     .OUTPUTS
-    If ensure is present then returns a normalized array of Drive Letters.
+        If ensure is present then returns a normalized array of Drive Letters.
 #>
 function Test-ParameterValid
 {
@@ -469,19 +473,21 @@ function Test-ParameterValid
 
 <#
     .SYNOPSIS
-    Mounts a Disk Image to a specific Drive Letter.
+        Mounts a Disk Image to a specific Drive Letter.
 
     .PARAMETER ImagePath
-    Specifies the path of the VHD or ISO file.
+        Specifies the path of the VHD or ISO file.
 
     .PARAMETER DriveLetter
-    Specifies the drive letter to mount this VHD or ISO to.
+        Specifies the drive letter to mount this VHD or ISO to.
 
     .PARAMETER StorageType
-    Specifies the storage type of a file. If the StorageType parameter is not specified, then the storage type is determined by file extension.
+        Specifies the storage type of a file. If the StorageType parameter is not
+        specified, then the storage type is determined by file extension.
 
     .PARAMETER Access
-    Allows a VHD file to be mounted in read-only or read-write mode. ISO files are mounted in read-only mode regardless of what parameter value you provide.
+        Allows a VHD file to be mounted in read-only or read-write mode. ISO files
+        are mounted in read-only mode regardless of what parameter value you provide.
 #>
 function Mount-DiskImageToLetter
 {

--- a/DSCResources/MSFT_WaitForDisk/MSFT_WaitForDisk.psm1
+++ b/DSCResources/MSFT_WaitForDisk/MSFT_WaitForDisk.psm1
@@ -10,19 +10,19 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_WaitForDisk'
 
 <#
     .SYNOPSIS
-    Returns the current state of the wait for disk resource.
+        Returns the current state of the wait for disk resource.
 
     .PARAMETER DiskId
-    Specifies the disk identifier for the disk to wait for.
+        Specifies the disk identifier for the disk to wait for.
 
     .PARAMETER DiskIdType
-    Specifies the identifier type the DiskId contains. Defaults to Number.
+        Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER RetryIntervalSec
-    Specifies the number of seconds to wait for the disk to become available.
+        Specifies the number of seconds to wait for the disk to become available.
 
     .PARAMETER RetryCount
-    The number of times to loop the retry interval while waiting for the disk.
+        The number of times to loop the retry interval while waiting for the disk.
 #>
 function Get-TargetResource
 {
@@ -67,19 +67,19 @@ function Get-TargetResource
 
 <#
     .SYNOPSIS
-    Sets the current state of the wait for disk resource.
+        Sets the current state of the wait for disk resource.
 
     .PARAMETER DiskId
-    Specifies the disk identifier for the disk to wait for.
+        Specifies the disk identifier for the disk to wait for.
 
     .PARAMETER DiskIdType
-    Specifies the identifier type the DiskId contains. Defaults to Number.
+        Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER RetryIntervalSec
-    Specifies the number of seconds to wait for the disk to become available.
+        Specifies the number of seconds to wait for the disk to become available.
 
     .PARAMETER RetryCount
-    The number of times to loop the retry interval while waiting for the disk.
+        The number of times to loop the retry interval while waiting for the disk.
 #>
 function Set-TargetResource
 {
@@ -148,19 +148,19 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-    Tests the current state of the wait for disk resource.
+        Tests the current state of the wait for disk resource.
 
     .PARAMETER DiskId
-    Specifies the disk identifier for the disk to wait for.
+        Specifies the disk identifier for the disk to wait for.
 
     .PARAMETER DiskIdType
-    Specifies the identifier type the DiskId contains. Defaults to Number.
+        Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER RetryIntervalSec
-    Specifies the number of seconds to wait for the disk to become available.
+        Specifies the number of seconds to wait for the disk to become available.
 
     .PARAMETER RetryCount
-    The number of times to loop the retry interval while waiting for the disk.
+        The number of times to loop the retry interval while waiting for the disk.
 #>
 function Test-TargetResource
 {

--- a/DSCResources/MSFT_WaitForVolume/MSFT_WaitForVolume.psm1
+++ b/DSCResources/MSFT_WaitForVolume/MSFT_WaitForVolume.psm1
@@ -10,16 +10,16 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_WaitForVolume'
 
 <#
     .SYNOPSIS
-    Returns the current state of the wait for drive resource.
+        Returns the current state of the wait for drive resource.
 
     .PARAMETER DriveLetter
-    Specifies the name of the drive to wait for.
+        Specifies the name of the drive to wait for.
 
     .PARAMETER RetryIntervalSec
-    Specifies the number of seconds to wait for the drive to become available.
+        Specifies the number of seconds to wait for the drive to become available.
 
     .PARAMETER RetryCount
-    The number of times to loop the retry interval while waiting for the drive.
+        The number of times to loop the retry interval while waiting for the drive.
 #>
 function Get-TargetResource
 {
@@ -58,16 +58,16 @@ function Get-TargetResource
 
 <#
     .SYNOPSIS
-    Sets the current state of the wait for drive resource.
+        Sets the current state of the wait for drive resource.
 
     .PARAMETER DriveLetter
-    Specifies the name of the drive to wait for.
+        Specifies the name of the drive to wait for.
 
     .PARAMETER RetryIntervalSec
-    Specifies the number of seconds to wait for the drive to become available.
+        Specifies the number of seconds to wait for the drive to become available.
 
     .PARAMETER RetryCount
-    The number of times to loop the retry interval while waiting for the drive.
+        The number of times to loop the retry interval while waiting for the drive.
 #>
 function Set-TargetResource
 {
@@ -119,8 +119,10 @@ function Set-TargetResource
 
             Start-Sleep -Seconds $RetryIntervalSec
 
-            # This command forces a refresh of the PS Drive subsystem.
-            # So triggers any "missing" drives to show up.
+            <#
+                This command forces a refresh of the PS Drive subsystem.
+                So triggers any "missing" drives to show up.
+            #>
             $null = Get-PSDrive
         } # if
     } # for
@@ -134,16 +136,16 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-    Tests the current state of the wait for drive resource.
+        Tests the current state of the wait for drive resource.
 
     .PARAMETER DriveLetter
-    Specifies the name of the drive to wait for.
+        Specifies the name of the drive to wait for.
 
     .PARAMETER RetryIntervalSec
-    Specifies the number of seconds to wait for the drive to become available.
+        Specifies the number of seconds to wait for the drive to become available.
 
     .PARAMETER RetryCount
-    The number of times to loop the retry interval while waiting for the drive.
+        The number of times to loop the retry interval while waiting for the drive.
 #>
 function Test-TargetResource
 {

--- a/Modules/StorageDsc.Common/StorageDsc.Common.psm1
+++ b/Modules/StorageDsc.Common/StorageDsc.Common.psm1
@@ -521,13 +521,13 @@ function Restart-ServiceIfExists
 
 <#
     .SYNOPSIS
-    Validates a Drive Letter, removing or adding the trailing colon if required.
+        Validates a Drive Letter, removing or adding the trailing colon if required.
 
     .PARAMETER DriveLetter
-    The Drive Letter string to validate.
+        The Drive Letter string to validate.
 
     .PARAMETER Colon
-    Will ensure the returned string will include or exclude a colon.
+        Will ensure the returned string will include or exclude a colon.
 #>
 function Assert-DriveLetterValid
 {
@@ -568,15 +568,15 @@ function Assert-DriveLetterValid
 
 <#
     .SYNOPSIS
-    Validates an Access Path, removing or adding the trailing slash if required.
-    If the Access Path does not exist or is not a folder then an exception will
-    be thrown.
+        Validates an Access Path, removing or adding the trailing slash if required.
+        If the Access Path does not exist or is not a folder then an exception will
+        be thrown.
 
     .PARAMETER AccessPath
-    The Access Path string to validate.
+        The Access Path string to validate.
 
     .PARAMETER Slash
-    Will ensure the returned path will include or exclude a slash.
+        Will ensure the returned path will include or exclude a slash.
 #>
 function Assert-AccessPathValid
 {
@@ -623,14 +623,14 @@ function Assert-AccessPathValid
 
 <#
     .SYNOPSIS
-    Retrieves a Disk object matching the disk Id and Id type
-    provided.
+        Retrieves a Disk object matching the disk Id and Id type
+        provided.
 
     .PARAMETER DiskId
-    Specifies the disk identifier for the disk to retrieve.
+        Specifies the disk identifier for the disk to retrieve.
 
     .PARAMETER DiskIdType
-    Specifies the identifier type the DiskId contains. Defaults to Number.
+        Specifies the identifier type the DiskId contains. Defaults to Number.
 #>
 function Get-DiskByIdentifier
 {
@@ -670,11 +670,11 @@ function Get-DiskByIdentifier
 
 <#
     .SYNOPSIS
-    Tests if any of the access paths from a partition are assigned
-    to a local path.
+        Tests if any of the access paths from a partition are assigned
+        to a local path.
 
     .PARAMETER AccessPath
-    Specifies the access paths that are assigned to the partition.
+        Specifies the access paths that are assigned to the partition.
 #>
 function Test-AccessPathAssignedToLocal
 {

--- a/Modules/StorageDsc.Common/StorageDsc.Common.psm1
+++ b/Modules/StorageDsc.Common/StorageDsc.Common.psm1
@@ -621,7 +621,6 @@ function Assert-AccessPathValid
     return $AccessPath
 } # end function Assert-AccessPathValid
 
-
 <#
     .SYNOPSIS
     Retrieves a Disk object matching the disk Id and Id type


### PR DESCRIPTION
#### Pull Request (PR) description

- DiskAccessPath:
  - Added function to force refresh of disk subsystem at the start of
    Set-TargetResource to prevent errors occuring when the disk access
    path is already assigned - See [Issue 121](https://github.com/PowerShell/StorageDsc/issues/121)

This PR also supercedes #152, #126 
 
#### This Pull Request (PR) fixes the following issues

- Fixes #121 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing this when you get a chance?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/storagedsc/209)
<!-- Reviewable:end -->
