### PR TITLE
Disk: Fix Partition MaxSize discrepency - Fixes #181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - WaitForDisk:
   - Added `Location` as a possible value for `DiskIdType`. This will select the
     disk based on the `Location` property returned by `Get-Disk`
+- Maximum size calculation now uses workaround so that
+  Test-TargetResource works properly - workaround for
+  [Issue #181](https://github.com/PowerShell/StorageDsc/issues/181).
 
 ## 4.8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@
 - Disk:
   - Added `Location` as a possible value for `DiskIdType`. This will select the
     disk based on the `Location` property returned by `Get-Disk`
+  - Maximum size calculation now uses workaround so that
+    Test-TargetResource works properly - workaround for
+    [Issue #181](https://github.com/PowerShell/StorageDsc/issues/181).
 - DiskAccessPath:
   - Added `Location` as a possible value for `DiskIdType`. This will select the
     disk based on the `Location` property returned by `Get-Disk`
 - WaitForDisk:
   - Added `Location` as a possible value for `DiskIdType`. This will select the
     disk based on the `Location` property returned by `Get-Disk`
-- Maximum size calculation now uses workaround so that
-  Test-TargetResource works properly - workaround for
-  [Issue #181](https://github.com/PowerShell/StorageDsc/issues/181).
 
 ## 4.8.0.0
 

--- a/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
+++ b/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
@@ -480,20 +480,7 @@ function Set-TargetResource
         #>
         if (-not ($PSBoundParameters.ContainsKey('Size')))
         {
-            <#
-                If the difference in size between the supported partition size
-                and the current partition size is less than 1MB then set the
-                required partition size to the current size. This will prevent
-                the partition from being resized.
-            #>
-            if (($supportedSize.SizeMax - $partition.Size) -lt 1MB)
-            {
-                $Size = $partition.Size
-            }
-            else
-            {
-                $Size = $supportedSize.SizeMax
-            }
+            $Size = $supportedSize.SizeMax
         }
 
         if ($assignedPartition.Size -ne $Size)
@@ -822,7 +809,21 @@ function Test-TargetResource
     {
         $supportedSize = ($partition | Get-PartitionSupportedSize)
 
-        $Size = $supportedSize.SizeMax
+        <#
+            If the difference in size between the supported partition size
+            and the current partition size is less than 1MB then set the
+            desired partition size to the current size. This will prevent
+            any size difference less than 1MB from trying to contiuously
+            resize. See https://github.com/PowerShell/StorageDsc/issues/181
+        #>
+        if (($supportedSize.SizeMax - $partition.Size) -lt 1MB)
+        {
+            $Size = $partition.Size
+        }
+        else
+        {
+            $Size = $supportedSize.SizeMax
+        }
     }
 
     if ($Size)

--- a/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
+++ b/DSCResources/MSFTDSC_Disk/MSFTDSC_Disk.psm1
@@ -480,7 +480,20 @@ function Set-TargetResource
         #>
         if (-not ($PSBoundParameters.ContainsKey('Size')))
         {
-            $Size = $supportedSize.SizeMax
+            <#
+                If the difference in size between the supported partition size
+                and the current partition size is less than 1MB then set the
+                required partition size to the current size. This will prevent
+                the partition from being resized.
+            #>
+            if (($supportedSize.SizeMax - $partition.Size) -lt 1MB)
+            {
+                $Size = $partition.Size
+            }
+            else
+            {
+                $Size = $supportedSize.SizeMax
+            }
         }
 
         if ($assignedPartition.Size -ne $Size)

--- a/DSCResources/MSFTDSC_Disk/README.md
+++ b/DSCResources/MSFTDSC_Disk/README.md
@@ -55,4 +55,5 @@ On some disks the _maximum supported partition size_ may differ from the actual
 size of a partition created when specifying the maximum size. This difference
 in reported size is always less than **1MB**, so if the reported _maximum supported
 partition size_ is less than **1MB** then the partition will be considered to be
-in the correct state.
+in the correct state. This is a work around for [this issue](https://windowsserver.uservoice.com/forums/301869-powershell/suggestions/36967870-get-partitionsupportedsize-and-msft-partition-clas)
+that has been reported on user voice and also discussed in [issue #181](https://github.com/PowerShell/StorageDsc/issues/181).

--- a/DSCResources/MSFTDSC_Disk/README.md
+++ b/DSCResources/MSFTDSC_Disk/README.md
@@ -25,6 +25,8 @@ table for the disk has been created.
 
 ## Known Issues
 
+### Defragsvc Conflict
+
 The 'defragsvc' service ('Optimize Drives') may cause the following errors when
 enabled with this resource. The following error may occur when testing the state
 of the resource:
@@ -41,6 +43,16 @@ this error. Use the `Service` resource in either the 'xPSDesiredStateConfgiurati
 or 'PSDSCResources' resource module to set the 'defragsvc' service is always
 stopped and set to manual start up.
 
+### Null Location
+
 The _Location_ for a disk may be `null` for some types of disk,
 e.g. file-based virtual disks. Physical disks or Virtual disks provided via a
 hypervisor or other hardware virtualization platform should not be affected.
+
+### Maximum Supported Partition Size
+
+On some disks the _maximum supported partition size_ may differ from the actual
+size of a partition created when specifying the maximum size. This difference
+in reported size is always less than **1MB**, so if the reported _maximum supported
+partition size_ is less than **1MB** then the partition will be considered to be
+in the correct state.

--- a/DSCResources/MSFT_DiskAccessPath/README.md
+++ b/DSCResources/MSFT_DiskAccessPath/README.md
@@ -23,6 +23,8 @@ of disk selection the disk must have been initialized by some other method.
 
 ## Known Issues
 
+### Null Location
+
 The _Location_ for a disk may be `null` for some types of disk,
 e.g. file-based virtual disks. Physical disks or Virtual disks provided via a
 hypervisor or other hardware virtualization platform should not be affected.

--- a/DSCResources/MSFT_WaitForDisk/README.md
+++ b/DSCResources/MSFT_WaitForDisk/README.md
@@ -22,6 +22,8 @@ of disk selection the disk must have been initialized by some other method.
 
 ## Known Issues
 
+### Null Location
+
 The _Location_ for a disk may be `null` for some types of disk,
 e.g. file-based virtual disks. Physical disks or Virtual disks provided via a
 hypervisor or other hardware virtualization platform should not be affected.

--- a/Tests/Integration/MSFTDSC_Disk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFTDSC_Disk.Integration.Tests.ps1
@@ -891,6 +891,116 @@ try
             }
         }
         #endregion
+
+        #region Integration Tests for size and maximum size
+        Context 'When maximum size is used, Test-TargetResource needs to report true even though Size and SizeMax are different.' {
+            BeforeAll {
+                # Create a VHD and attach it to the computer
+                $VHDPath = Join-Path -Path $TestDrive `
+                    -ChildPath 'TestDisk.vhd'
+                $null = New-VDisk -Path $VHDPath -SizeInMB 1024 -Initialize
+                $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
+                $diskImage = Get-DiskImage -ImagePath $VHDPath
+                $disk = Get-Disk -Number $diskImage.Number
+                $FSLabelA = 'TestDiskA'
+                $FSLabelB = 'TestDiskB'
+
+                # Get a spare drive letter
+                $lastDrive = ((Get-Volume).DriveLetter | Sort-Object | Select-Object -Last 1)
+                $driveLetterA = [char](([int][char]$lastDrive) + 1)
+                $driveLetterB = [char](([int][char]$lastDrive) + 2)
+            }
+
+            Context "When using fixed size Disk Number $($disk.Number)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName       = 'localhost'
+                                    DriveLetter    = $driveLetterA
+                                    DiskId         = $disk.Number
+                                    DiskIdType     = 'Number'
+                                    PartitionStyle = 'GPT'
+                                    FSLabel        = $FSLabelA
+                                    Size           = 100MB
+                                }
+                            )
+                        }
+
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and size should match' {
+                    $current = $script:currentConfiguration | Where-Object -FilterScript {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.Size         | Should -Be 100MB
+                }
+            }
+
+            Context "When using maximum size for new volume on Disk Number $($disk.Number)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName       = 'localhost'
+                                    DriveLetter    = $driveLetterA
+                                    DiskId         = $disk.Number
+                                    DiskIdType     = 'Number'
+                                    PartitionStyle = 'GPT'
+                                    FSLabel        = $FSLabelA
+                                }
+                            )
+                        }
+
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Test-DscConfiguration should return True, indicating that partition size instead of SizeMax was used' {
+                    Test-DscConfiguration | Should -Be $true
+                }
+            }
+
+            AfterAll {
+                Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
+                Remove-Item -Path $VHDPath -Force
+            }
+        }
+        #endregion
     }
 }
 finally

--- a/Tests/Unit/MSFTDSC_Disk.Tests.ps1
+++ b/Tests/Unit/MSFTDSC_Disk.Tests.ps1
@@ -2667,7 +2667,8 @@ try
                     -MockWith {
                         return @{
                             SizeMin = 0
-                            SizeMax = $script:mockedPartition.Size + 1024
+                            # Adding >1MB, otherwise workaround for wrong SizeMax is triggered
+                            SizeMax = $script:mockedPartition.Size + 1.1MB
                         }
                     } `
                     -Verifiable
@@ -2727,7 +2728,8 @@ try
                     -MockWith {
                         return @{
                             SizeMin = 0
-                            SizeMax = $script:mockedPartition.Size + 1024
+                            # Adding >1MB, otherwise workaround for wrong SizeMax is triggered
+                            SizeMax = $script:mockedPartition.Size + 1.1MB
                         }
                     } `
                     -Verifiable
@@ -2761,6 +2763,59 @@ try
                     Assert-MockCalled -CommandName Get-PartitionSupportedSize -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
+                }
+            }
+
+            Context 'When testing matching partition size with AllowDestructive and without Size specified using Disk Number' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter $script:parameterFilter_MockedDisk0Number `
+                    -MockWith { $script:mockedDisk0Gpt } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Partition `
+                    -MockWith { $script:mockedPartition } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-PartitionSupportedSize `
+                    -MockWith {
+                        return @{
+                            SizeMin = 0
+                            SizeMax = $script:mockedPartition.Size
+                        }
+                    } `
+                    -Verifiable
+                Mock -CommandName Get-Volume -Verifiable
+                Mock -CommandName Get-CimInstance -Verifiable
+
+                $script:result = $null
+
+                It 'Should not throw an exception' {
+                    {
+                        $script:result = Test-TargetResource `
+                            -DiskId $script:mockedDisk0Gpt.Number `
+                            -DriveLetter $script:testDriveLetter `
+                            -AllocationUnitSize 4096 `
+                            -AllowDestructive $true `
+                            -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be true' {
+                    $script:result | Should -Be $true
+                }
+
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMock
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter $script:parameterFilter_MockedDisk0Number
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-PartitionSupportedSize -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
                 }
             }
 

--- a/Tests/Unit/MSFTDSC_Disk.Tests.ps1
+++ b/Tests/Unit/MSFTDSC_Disk.Tests.ps1
@@ -2766,7 +2766,7 @@ try
                 }
             }
 
-            Context 'When testing matching partition size with AllowDestructive and without Size specified using Disk Number' {
+            Context 'When testing matching partition size with a less than 1MB difference in desired size and with AllowDestructive and without Size specified using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
                     -CommandName Get-DiskByIdentifier `
@@ -2784,7 +2784,7 @@ try
                     -MockWith {
                         return @{
                             SizeMin = 0
-                            SizeMax = $script:mockedPartition.Size
+                            SizeMax = $script:mockedPartition.Size + 0.98MB
                         }
                     } `
                     -Verifiable


### PR DESCRIPTION

#### Pull Request (PR) description

This PR introduces a workaround that fixes issue #181 where the reported maximum supported size of a partition would be approximately 1MB bigger than the actual size of the partition. As long as it is unclear why the New-Partition and Get-PartitionSupportedSize cmdlets report different data if neither Offset nor Alignment parameters are used, this workaround should remain in place.

If this is not the case, Test-TargetResource for a disk configured to use the remaining size will always return false and trigger an endless cycle of LCM runs.

This PR replaces #197.

#### This Pull Request (PR) fixes the following issues

- Fixes #181 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing when you have a moment?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/storagedsc/213)
<!-- Reviewable:end -->
